### PR TITLE
Put kubectl and friends in env/bin if it's active

### DIFF
--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -34,6 +34,10 @@ def load_arguments(self, _):
     #                  default=_get_default_install_location('kubectl'))
 
 
+def get_virtualenv():
+    return os.getenv("VIRTUAL_ENV")
+
+
 def _get_default_install_location(exe_name):
     system = platform.system()
     if system == 'Windows':
@@ -43,7 +47,11 @@ def _get_default_install_location(exe_name):
         install_location = os.path.join(
             home_dir, r'.azure-{0}\{0}.exe'.format(exe_name))
     elif system in ('Linux', 'Darwin'):
-        install_location = '/usr/local/bin/{}'.format(exe_name)
+        venv = get_virtualenv()
+        if venv:
+            install_location = '{}/bin/{}'.format(venv, exe_name)
+        else:
+            install_location = '/usr/local/bin/{}'.format(exe_name)
     else:
         install_location = None
     return install_location


### PR DESCRIPTION
**Description**

This should be more friendly for developers since `/usr/local/bin` isn't writeable by default.

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
