### PR TITLE
Improve `az capi create` with status, kubeconfig, and --yes flag

### DIFF
--- a/src/capi/HISTORY.rst
+++ b/src/capi/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.2
+++++++
+* Improve `az capi create` with status, kubeconfig, and --yes flag
+
 0.0.1
 ++++++
 * Initial release.

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -16,7 +16,6 @@ import re
 import stat
 import string
 import subprocess
-import sys
 import time
 
 from jinja2 import Environment, PackageLoader

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -40,7 +40,7 @@ from ._params import _get_default_install_location
 logger = get_logger(__name__)  # pylint: disable=invalid-name
 
 
-def init_environment(cmd):
+def init_environment(cmd, prompt=True):
     check_preqreqs(cmd, install=True)
     # Create a management cluster if needed
     try:
@@ -49,22 +49,38 @@ def init_environment(cmd):
         if str(err) == "No CAPZ installation found":
             _install_capz_components()
     except subprocess.CalledProcessError:
-        providers = ['AKS - a managed cluster in Azure',
-                     'kind - a local docker-based cluster', "exit - don't create a management cluster"]
-        prompt = """\
-No Kubernetes cluster was found using the default configuration.
+        if prompt:
+            choices = ["kind - a local docker-based cluster",
+                       "AKS - a managed cluster in Azure",
+                       "exit - don't create a management cluster"]
+            prompt = """\
+    No Kubernetes cluster was found using the default configuration.
 
-Cluster API needs a "management cluster" to run its components.
-Learn more from the Cluster API Book:
-  https://cluster-api.sigs.k8s.io/user/concepts.html
+    Cluster API needs a "management cluster" to run its components.
+    Learn more from the Cluster API Book:
+    https://cluster-api.sigs.k8s.io/user/concepts.html
 
-Where should we create a management cluster?
-"""
-        choice_index = prompt_choice_list(prompt, providers)
+    Where should we create a management cluster?
+    """
+            choice_index = prompt_choice_list(prompt, choices)
+        else:
+            choice_index = 0
         random_id = ''.join(random.choices(
             string.ascii_lowercase + string.digits, k=6))
         cluster_name = "capi-manager-" + random_id
         if choice_index == 0:
+            logger.info("kind management cluster")
+            # Install kind
+            kind_path = "kind"
+            if not which("kind"):
+                kind_path = install_kind(cmd)
+            cmd = [kind_path, "create", "cluster", "--name", cluster_name]
+            try:
+                output = subprocess.check_output(cmd, universal_newlines=True)
+                logger.info("%s returned:\n%s", " ".join(cmd), output)
+            except subprocess.CalledProcessError as err:
+                raise UnclassifiedUserFault(err)
+        elif choice_index == 1:
             logger.info("AKS management cluster")
             cmd = ["az", "group", "create", "-l",
                    "southcentralus", "--name", cluster_name]
@@ -75,18 +91,6 @@ Where should we create a management cluster?
                 raise UnclassifiedUserFault(err)
             cmd = ["az", "aks", "create", "-g",
                    cluster_name, "--name", cluster_name]
-            try:
-                output = subprocess.check_output(cmd, universal_newlines=True)
-                logger.info("%s returned:\n%s", " ".join(cmd), output)
-            except subprocess.CalledProcessError as err:
-                raise UnclassifiedUserFault(err)
-        elif choice_index == 1:
-            logger.info("kind management cluster")
-            # Install kind
-            kind_path = "kind"
-            if not which("kind"):
-                kind_path = install_kind(cmd)
-            cmd = [kind_path, "create", "cluster", "--name", cluster_name]
             try:
                 output = subprocess.check_output(cmd, universal_newlines=True)
                 logger.info("%s returned:\n%s", " ".join(cmd), output)
@@ -209,7 +213,6 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         node_machine_type=os.environ.get("AZURE_NODE_MACHINE_TYPE"),
         node_machine_count=os.environ.get("AZURE_NODE_MACHINE_COUNT", 3),
         kubernetes_version=os.environ.get("AZURE_KUBERNETES_VERSION", "1.20.2"),
-        # azure_cloud=os.environ.get("AZURE_ENVIRONMENT", "AzurePublicCloud"),
         subscription_id=os.environ.get("AZURE_SUBSCRIPTION_ID"),
         ssh_public_key=os.environ.get("AZURE_SSH_PUBLIC_KEY_B64", ""),
         vnet_name=None,
@@ -218,9 +221,8 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         windows=False,
         yes=False):
     # Generate the cluster configuration
-    env = Environment(loader=PackageLoader(
-        __name__, "templates"), auto_reload=False)
-    logger.info("Available templates: %s", env.list_templates())
+    env = Environment(loader=PackageLoader(__name__, "templates"), auto_reload=False)
+    logger.debug("Available templates: %s", env.list_templates())
     template = env.get_template("base.jinja")
 
     args = {
@@ -238,16 +240,6 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         "NODEPOOL_TYPE": "machinepool" if machinepool else "machinedeployment",
     }
     manifest = template.render(args)
-
-    # TODO: Some CAPZ options need to be set as env vars, not clusterctl arguments.
-    # os.environ.update(
-    #     {
-    #         "AZURE_CONTROL_PLANE_MACHINE_TYPE": control_plane_machine_type,
-    #         "AZURE_NODE_MACHINE_TYPE": node_machine_type,
-    #         "AZURE_LOCATION": location,
-    #         "AZURE_ENVIRONMENT": azure_cloud,
-    #     }
-    # )
     filename = capi_name + ".yaml"
     with open(filename, "w") as manifest_file:
         manifest_file.write(manifest)
@@ -256,34 +248,8 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
     msg = 'Do you want to create this Kubernetes cluster "{}" in the Azure resource group "{}"?'.format(
         capi_name, resource_group_name)
     if yes or prompt_y_n(msg, default="n"):
-        init_environment(cmd)
+        init_environment(cmd, not yes)
 
-        # Prompt to create resource group if it doesn't exist
-        from azure.cli.core.commands.client_factory import get_mgmt_service_client
-        from azure.cli.core.profiles import ResourceType
-
-        resource_client = get_mgmt_service_client(
-            cmd.cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES)
-        if not resource_client.resource_groups.check_existence(resource_group_name):
-            logger.warning("Couldn't find the specified resource group.")
-            if not location:
-                raise RequiredArgumentMissingError(
-                    'Please specify a location so a resource group can be created.')
-            create = yes
-            if not create:
-                msg = 'Do you want to create a new resource group named "{}" in Azure\'s {} region?'.format(
-                    resource_group_name, location)
-                create = prompt_y_n(msg, default="n")
-            if create:
-                rg_model = resource_client.models().ResourceGroup
-                # TODO: add tags to resource group?
-                parameters = rg_model(location=location)
-                output = resource_client.resource_groups.create_or_update(
-                    resource_group_name, parameters)
-                logger.info(output)
-                logger.warning("Created resource group %s in %s.", resource_group_name, location)
-        # Check for general prerequisites
-        # init_environment(cmd)
         # Identify or create a Kubernetes v1.16+ management cluster
         find_management_cluster_retry(cmd.cli_ctx)
 
@@ -294,7 +260,9 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
             logger.info("%s returned:\n%s", " ".join(cmd), output)
         except subprocess.CalledProcessError as err:
             raise UnclassifiedUserFault(err)
-        # TODO: create RG for user with AAD Pod ID scoped to it
+
+        # TODO: show the cluster's initialization progress
+        # TODO: write the kubeconfig for the workload cluster to a file
 
 
 def delete_workload_cluster(cmd):
@@ -380,7 +348,7 @@ def find_management_cluster_retry(cli_ctx, delay=3):
 
 def find_management_cluster():
     cmd = ["kubectl", "cluster-info"]
-    match = check_cmd(cmd, r"Kubernetes control plane.*?is running")
+    match = check_cmd(cmd, r"Kubernetes .*?is running")
     if match is None:
         raise ResourceNotFoundError("No accessible Kubernetes cluster found")
     cmd = ["kubectl", "get", "pods", "--namespace", "capz-system"]

--- a/src/capi/setup.py
+++ b/src/capi/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 
 # Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.0.1'
+VERSION = '0.0.2'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
**Description**

Makes several small improvements to the `az capi create` flow:
  - Honor --yes flag when creating management cluster
  - Show `clusterctl describe` output after creating workload cluster
  - Save kubeconfig after creating workload cluster
  - Default to `kind` when creating management cluster
  - Clean up dead code

**History Notes**

Improve `az capi create` with status, kubeconfig, and --yes flag

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
