### PR TITLE
Fix writing of kubeconfig file

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -277,9 +277,9 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         output = subprocess.check_output(cmd, universal_newlines=True)
     except subprocess.CalledProcessError as err:
         raise UnclassifiedUserFault(err)
-    filename = capi_name + ".cfg"
-    with open(filename, "w") as manifest_file:
-        manifest_file.write(manifest)
+    filename = capi_name + ".kubeconfig"
+    with open(filename, "w") as kubeconfig_file:
+        kubeconfig_file.write(output)
     logger.warning("wrote kubeconfig file to %s", filename)
 
 


### PR DESCRIPTION
**Description**

Fixes a bug in writing the workload cluster kubeconfig file.

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
