### PR TITLE
Add unit test for "az capi show"

### DIFF
--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -20,18 +20,11 @@ def load_arguments(self, _):
     from azure.cli.core.commands.parameters import tags_type
 
     capi_name_type = CLIArgumentType(
-        options_list='--capi-name-name', help='Name of the Capi.', id_part='name')
+        options_list='--capi-name-name', help='Name of the CAPI Kubernetes cluster.')
 
     with self.argument_context('capi') as ctx:
         ctx.argument('tags', tags_type)
         ctx.argument('capi_name', capi_name_type, options_list=['--name', '-n'])
-
-    with self.argument_context('capi list') as ctx:
-        ctx.argument('capi_name', capi_name_type, id_part=None)
-
-    # with self.argument_context('capi init') as ctx:
-    #     ctx.argument('install_location', type=file_type, completer=FilesCompleter(),
-    #                  default=_get_default_install_location('kubectl'))
 
 
 def get_virtualenv():
@@ -39,6 +32,7 @@ def get_virtualenv():
 
 
 def _get_default_install_location(exe_name):
+    install_location = None
     system = platform.system()
     if system == 'Windows':
         home_dir = os.environ.get('USERPROFILE')
@@ -52,6 +46,4 @@ def _get_default_install_location(exe_name):
             install_location = '{}/bin/{}'.format(venv, exe_name)
         else:
             install_location = '/usr/local/bin/{}'.format(exe_name)
-    else:
-        install_location = None
     return install_location

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -5,6 +5,7 @@
 
 import os
 import unittest
+from unittest.mock import MagicMock, patch
 
 from azure_devtools.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
@@ -15,15 +16,23 @@ TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
 class CapiScenarioTest(ScenarioTest):
 
-    # @ResourceGroupPreparer(name_prefix='cli_test_capi')
-    # def test_capi(self, resource_group):
-    def test_capi(self):
-        pass
+    @patch('azext_capi.custom.exit_if_no_management_cluster')
+    def test_capi_list(self, mock_def):
 
-        # self.kwargs.update({
-        #     'name': 'test1'
-        # })
-        #
+        with patch('subprocess.check_output') as mock:
+            mock.return_value = AZ_CAPI_SHOW_JSON
+            self.cmd('capi list --output json', checks=[
+                self.check('items[0].kind', 'Cluster'),
+                self.check('items[0].metadata.name', 'testcluster1'),
+                self.check('items[1].kind', 'Cluster'),
+                self.check('items[1].metadata.name', 'testcluster2'),
+            ])
+
+            count = len(self.cmd("capi list").get_output_in_json())
+            self.assertEqual(count, 4)  # "apiVersion", "items", kind", and "metadata".
+
+            self.assertEqual(mock.call_count, 2)
+
         # self.cmd('capi create -g {rg} -n {name} --tags foo=doo', checks=[
         #     self.check('tags.foo', 'doo'),
         #     self.check('name', '{name}')
@@ -40,3 +49,319 @@ class CapiScenarioTest(ScenarioTest):
         # self.cmd('capi delete -g {rg} -n {name}')
         # final_count = len(self.cmd('capi list').get_output_in_json())
         # self.assertTrue(final_count, count - 1)
+
+
+AZ_CAPI_SHOW_JSON = """\
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "cluster.x-k8s.io/v1alpha3",
+      "kind": "Cluster",
+      "metadata": {
+        "annotations": {
+        },
+        "creationTimestamp": "2021-03-31T19:18:10Z",
+        "finalizers": [
+          "cluster.cluster.x-k8s.io"
+        ],
+        "generation": 2,
+        "labels": {
+          "cni": "calico"
+        },
+        "managedFields": [
+          {
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                },
+                "f:labels": {
+                  ".": {},
+                  "f:cni": {}
+                }
+              },
+              "f:spec": {
+                ".": {},
+                "f:clusterNetwork": {
+                  ".": {},
+                  "f:pods": {
+                    ".": {},
+                    "f:cidrBlocks": {}
+                  }
+                },
+                "f:controlPlaneRef": {
+                  ".": {},
+                  "f:apiVersion": {},
+                  "f:kind": {},
+                  "f:name": {}
+                },
+                "f:infrastructureRef": {
+                  ".": {},
+                  "f:apiVersion": {},
+                  "f:kind": {},
+                  "f:name": {}
+                }
+              }
+            },
+            "manager": "kubectl-client-side-apply",
+            "operation": "Update",
+            "time": "2021-03-31T19:18:10Z"
+          },
+          {
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:finalizers": {
+                  ".": {},
+                  "v:cluster.cluster.x-k8s.io": {}
+                }
+              },
+              "f:spec": {
+                "f:controlPlaneEndpoint": {
+                  "f:host": {},
+                  "f:port": {}
+                }
+              },
+              "f:status": {
+                ".": {},
+                "f:conditions": {},
+                "f:controlPlaneInitialized": {},
+                "f:failureDomains": {
+                  ".": {},
+                  "f:1": {
+                    ".": {},
+                    "f:controlPlane": {}
+                  },
+                  "f:2": {
+                    ".": {},
+                    "f:controlPlane": {}
+                  },
+                  "f:3": {
+                    ".": {},
+                    "f:controlPlane": {}
+                  }
+                },
+                "f:infrastructureReady": {},
+                "f:observedGeneration": {},
+                "f:phase": {}
+              }
+            },
+            "manager": "manager",
+            "operation": "Update",
+            "time": "2021-03-31T19:20:58Z"
+          }
+        ],
+        "name": "testcluster1",
+        "namespace": "default",
+        "resourceVersion": "2566",
+        "uid": "ab39bad4-569a-4e5d-874b-775525b71785"
+      },
+      "spec": {
+        "clusterNetwork": {
+          "pods": {
+            "cidrBlocks": [
+              "192.168.0.0/16"
+            ]
+          }
+        },
+        "controlPlaneEndpoint": {
+          "host": "testcluster1-b4de9daa.southcentralus.cloudapp.azure.com",
+          "port": 6443
+        },
+        "controlPlaneRef": {
+          "apiVersion": "controlplane.cluster.x-k8s.io/v1alpha3",
+          "kind": "KubeadmControlPlane",
+          "name": "testcluster1-control-plane",
+          "namespace": "default"
+        },
+        "infrastructureRef": {
+          "apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+          "kind": "AzureCluster",
+          "name": "testcluster1",
+          "namespace": "default"
+        }
+      },
+      "status": {
+        "conditions": [
+          {
+            "lastTransitionTime": "2021-03-31T19:21:53Z",
+            "status": "True",
+            "type": "Ready"
+          },
+          {
+            "lastTransitionTime": "2021-03-31T19:21:53Z",
+            "status": "True",
+            "type": "ControlPlaneReady"
+          },
+          {
+            "lastTransitionTime": "2021-03-31T19:18:53Z",
+            "status": "True",
+            "type": "InfrastructureReady"
+          }
+        ],
+        "controlPlaneInitialized": true,
+        "failureDomains": {
+          "1": {
+            "controlPlane": true
+          },
+          "2": {
+            "controlPlane": true
+          },
+          "3": {
+            "controlPlane": true
+          }
+        },
+        "infrastructureReady": true,
+        "observedGeneration": 2,
+        "phase": "Provisioned"
+      }
+    },
+    {
+      "apiVersion": "cluster.x-k8s.io/v1alpha3",
+      "kind": "Cluster",
+      "metadata": {
+        "annotations": {
+        },
+        "creationTimestamp": "2021-03-31T19:52:29Z",
+        "finalizers": [
+          "cluster.cluster.x-k8s.io"
+        ],
+        "generation": 1,
+        "labels": {
+          "cni": "calico"
+        },
+        "managedFields": [
+          {
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                },
+                "f:labels": {
+                  ".": {},
+                  "f:cni": {}
+                }
+              },
+              "f:spec": {
+                ".": {},
+                "f:clusterNetwork": {
+                  ".": {},
+                  "f:pods": {
+                    ".": {},
+                    "f:cidrBlocks": {}
+                  }
+                },
+                "f:controlPlaneRef": {
+                  ".": {},
+                  "f:apiVersion": {},
+                  "f:kind": {},
+                  "f:name": {}
+                },
+                "f:infrastructureRef": {
+                  ".": {},
+                  "f:apiVersion": {},
+                  "f:kind": {},
+                  "f:name": {}
+                }
+              }
+            },
+            "manager": "kubectl-client-side-apply",
+            "operation": "Update",
+            "time": "2021-03-31T19:52:29Z"
+          },
+          {
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:finalizers": {
+                  ".": {},
+                  "v:cluster.cluster.x-k8s.io": {}
+                }
+              },
+              "f:status": {
+                ".": {},
+                "f:conditions": {},
+                "f:observedGeneration": {},
+                "f:phase": {}
+              }
+            },
+            "manager": "manager",
+            "operation": "Update",
+            "time": "2021-03-31T19:52:29Z"
+          }
+        ],
+        "name": "testcluster2",
+        "namespace": "default",
+        "resourceVersion": "10362",
+        "uid": "22444cab-c63b-4593-a2db-00ff2bbfe605"
+      },
+      "spec": {
+        "clusterNetwork": {
+          "pods": {
+            "cidrBlocks": [
+              "192.168.0.0/16"
+            ]
+          }
+        },
+        "controlPlaneEndpoint": {
+          "host": "",
+          "port": 0
+        },
+        "controlPlaneRef": {
+          "apiVersion": "controlplane.cluster.x-k8s.io/v1alpha3",
+          "kind": "KubeadmControlPlane",
+          "name": "testcluster2-control-plane",
+          "namespace": "default"
+        },
+        "infrastructureRef": {
+          "apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+          "kind": "AzureCluster",
+          "name": "testcluster2",
+          "namespace": "default"
+        }
+      },
+      "status": {
+        "conditions": [
+          {
+            "lastTransitionTime": "2021-03-31T19:52:29Z",
+            "reason": "WaitingForControlPlane",
+            "severity": "Info",
+            "status": "False",
+            "type": "Ready"
+          },
+          {
+            "lastTransitionTime": "2021-03-31T19:52:29Z",
+            "reason": "WaitingForControlPlane",
+            "severity": "Info",
+            "status": "False",
+            "type": "ControlPlaneReady"
+          },
+          {
+            "lastTransitionTime": "2021-03-31T19:52:29Z",
+            "reason": "WaitingForInfrastructure",
+            "severity": "Info",
+            "status": "False",
+            "type": "InfrastructureReady"
+          }
+        ],
+        "observedGeneration": 1,
+        "phase": "Provisioning"
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}
+"""


### PR DESCRIPTION
**Description**

Adds a heavily mocked unit test for `az capi show`. This should be a template for fleshing out UTs for the rest of the commands.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
