### PR TITLE
Add unit test and code coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit =
+    */tests/*
+source =
+    src/
+branch = True

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         source env/bin/activate
 
-        azdev test
+        azdev test --pytest-args --cov=src
 
     - name: Build extension
       run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,11 @@
         "**/.git/objects/**": true,
         "**/.git/subtree-cache/**": true,
         "**/env/**": true
-    }
+    },
+    "python.testing.pytestArgs": [
+        "src"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 azdev
 black
+coverage
 Jinja2
 MarkupSafe
+pytest-cov

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -20,7 +20,7 @@ class CapiScenarioTest(ScenarioTest):
     def test_capi_list(self, mock_def):
 
         with patch('subprocess.check_output') as mock:
-            mock.return_value = AZ_CAPI_SHOW_JSON
+            mock.return_value = AZ_CAPI_LIST_JSON
             self.cmd('capi list --output json', checks=[
                 self.check('items[0].kind', 'Cluster'),
                 self.check('items[0].metadata.name', 'testcluster1'),
@@ -29,29 +29,31 @@ class CapiScenarioTest(ScenarioTest):
             ])
 
             count = len(self.cmd("capi list").get_output_in_json())
-            self.assertEqual(count, 4)  # "apiVersion", "items", kind", and "metadata".
+            self.assertEqual(count, 4)  # "apiVersion", "items", "kind", and "metadata".
 
             self.assertEqual(mock.call_count, 2)
 
-        # self.cmd('capi create -g {rg} -n {name} --tags foo=doo', checks=[
-        #     self.check('tags.foo', 'doo'),
-        #     self.check('name', '{name}')
-        # ])
-        # self.cmd('capi update -g {rg} -n {name} --tags foo=boo', checks=[
-        #     self.check('tags.foo', 'boo')
-        # ])
-        # count = len(self.cmd('capi list').get_output_in_json())
-        # self.cmd('capi show - {rg} -n {name}', checks=[
-        #     self.check('name', '{name}'),
-        #     self.check('resourceGroup', '{rg}'),
-        #     self.check('tags.foo', 'boo')
-        # ])
-        # self.cmd('capi delete -g {rg} -n {name}')
-        # final_count = len(self.cmd('capi list').get_output_in_json())
-        # self.assertTrue(final_count, count - 1)
+    @patch('azext_capi.custom.exit_if_no_management_cluster')
+    def test_capi_show(self, mock_def):
+        # Test that error is raised if no args are passed
+        with self.assertRaises(SystemExit):
+            self.cmd('capi show')
+
+        with patch('subprocess.check_output') as mock:
+            mock.return_value = AZ_CAPI_SHOW_JSON
+            self.cmd('capi show --name testcluster1 --output json', checks=[
+                self.check('kind', 'Cluster'),
+                self.check('metadata.name', 'testcluster1'),
+            ])
+
+            count = len(self.cmd("capi show --name testcluster1").get_output_in_json())
+            self.assertEqual(count, 5)  # "apiVersion", "kind", "metadata", "spec", and "status"
+
+            self.assertEqual(mock.call_count, 2)
 
 
-AZ_CAPI_SHOW_JSON = """\
+
+AZ_CAPI_LIST_JSON = """\
 {
   "apiVersion": "v1",
   "items": [
@@ -362,6 +364,146 @@ AZ_CAPI_SHOW_JSON = """\
   "metadata": {
     "resourceVersion": "",
     "selfLink": ""
+  }
+}
+"""
+
+AZ_CAPI_SHOW_JSON = """\
+{
+  "apiVersion": "cluster.x-k8s.io/v1alpha3",
+  "kind": "Cluster",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\\"apiVersion\\":\\"cluster.x-k8s.io/v1alpha3\\",\\"kind\\":\\"Cluster\\",\\"metadata\\":{\\"annotations\\":{},\\"labels\\":{\\"cni\\":\\"calico\\"},\\"name\\":\\"testcluster1\\",\\"namespace\\":\\"default\\"},\\"spec\\":{\\"clusterNetwork\\":{\\"pods\\":{\\"cidrBlocks\\":[\\"192.168.0.0/16\\"]}},\\"controlPlaneRef\\":{\\"apiVersion\\":\\"controlplane.cluster.x-k8s.io/v1alpha3\\",\\"kind\\":\\"KubeadmControlPlane\\",\\"name\\":\\"testcluster1-control-plane\\"},\\"infrastructureRef\\":{\\"apiVersion\\":\\"infrastructure.cluster.x-k8s.io/v1alpha3\\",\\"kind\\":\\"AzureCluster\\",\\"name\\":\\"testcluster1\\"}}}\\n"
+    },
+    "creationTimestamp": "2021-04-05T15:34:38Z",
+    "finalizers": [
+      "cluster.cluster.x-k8s.io"
+    ],
+    "generation": 1,
+    "labels": {
+      "cni": "calico"
+    },
+    "managedFields": [
+      {
+        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": {
+          "f:metadata": {
+            "f:annotations": {
+              ".": {},
+              "f:kubectl.kubernetes.io/last-applied-configuration": {}
+            },
+            "f:labels": {
+              ".": {},
+              "f:cni": {}
+            }
+          },
+          "f:spec": {
+            ".": {},
+            "f:clusterNetwork": {
+              ".": {},
+              "f:pods": {
+                ".": {},
+                "f:cidrBlocks": {}
+              }
+            },
+            "f:controlPlaneRef": {
+              ".": {},
+              "f:apiVersion": {},
+              "f:kind": {},
+              "f:name": {}
+            },
+            "f:infrastructureRef": {
+              ".": {},
+              "f:apiVersion": {},
+              "f:kind": {},
+              "f:name": {}
+            }
+          }
+        },
+        "manager": "kubectl-client-side-apply",
+        "operation": "Update",
+        "time": "2021-04-05T15:34:38Z"
+      },
+      {
+        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": {
+          "f:metadata": {
+            "f:finalizers": {
+              ".": {},
+              "v:\\"cluster.cluster.x-k8s.io\\"": {}
+            }
+          },
+          "f:status": {
+            ".": {},
+            "f:conditions": {},
+            "f:observedGeneration": {},
+            "f:phase": {}
+          }
+        },
+        "manager": "manager",
+        "operation": "Update",
+        "time": "2021-04-05T15:34:38Z"
+      }
+    ],
+    "name": "testcluster1",
+    "namespace": "default",
+    "resourceVersion": "310437",
+    "uid": "c6cac420-e480-4b05-95fe-e46e0e0926db"
+  },
+  "spec": {
+    "clusterNetwork": {
+      "pods": {
+        "cidrBlocks": [
+          "192.168.0.0/16"
+        ]
+      }
+    },
+    "controlPlaneEndpoint": {
+      "host": "",
+      "port": 0
+    },
+    "controlPlaneRef": {
+      "apiVersion": "controlplane.cluster.x-k8s.io/v1alpha3",
+      "kind": "KubeadmControlPlane",
+      "name": "testcluster1-control-plane",
+      "namespace": "default"
+    },
+    "infrastructureRef": {
+      "apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+      "kind": "AzureCluster",
+      "name": "testcluster1",
+      "namespace": "default"
+    }
+  },
+  "status": {
+    "conditions": [
+      {
+        "lastTransitionTime": "2021-04-05T15:34:40Z",
+        "reason": "WaitingForControlPlane",
+        "severity": "Info",
+        "status": "False",
+        "type": "Ready"
+      },
+      {
+        "lastTransitionTime": "2021-04-05T15:34:40Z",
+        "reason": "WaitingForControlPlane",
+        "severity": "Info",
+        "status": "False",
+        "type": "ControlPlaneReady"
+      },
+      {
+        "lastTransitionTime": "2021-04-05T15:34:38Z",
+        "reason": "WaitingForInfrastructure",
+        "severity": "Info",
+        "status": "False",
+        "type": "InfrastructureReady"
+      }
+    ],
+    "observedGeneration": 1,
+    "phase": "Provisioning"
   }
 }
 """

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -52,7 +52,6 @@ class CapiScenarioTest(ScenarioTest):
             self.assertEqual(mock.call_count, 2)
 
 
-
 AZ_CAPI_LIST_JSON = """\
 {
   "apiVersion": "v1",


### PR DESCRIPTION
**Description**

Adds a unit test for "az capi show" and create a .coverage file when running unit tests in GH actions.

This isn't hooked up to coverage tracking or an online coverage report (yet).

**History Notes**



---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
