### PR TITLE
Retry fetching kubeconfig when creating workload cluster

### DIFF
--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -17,14 +17,12 @@ from knack.arguments import CLIArgumentType
 def load_arguments(self, _):
     """Loads command arguments into the parser."""
 
-    from azure.cli.core.commands.parameters import tags_type
-
     capi_name_type = CLIArgumentType(
         options_list='--capi-name-name', help='Name of the CAPI Kubernetes cluster.')
 
     with self.argument_context('capi') as ctx:
-        ctx.argument('tags', tags_type)
         ctx.argument('capi_name', capi_name_type, options_list=['--name', '-n'])
+        ctx.argument('yes', options_list=['--yes', '-y'])
 
 
 def get_virtualenv():


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

Smooths out the happy path (with `--yes`) so it ends with a workload cluster's kubeconfig being written locally.

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
