### PR TITLE
Add phase to table view of clusters

### DIFF
--- a/src/capi/azext_capi/_format.py
+++ b/src/capi/azext_capi/_format.py
@@ -11,6 +11,7 @@ This module contains JMESPath queries to format output for the az capi extension
 CLUSTER_TABLE_FORMAT = """\
 {
     name: metadata.name,
+    phase: status.phase,
     created: metadata.creationTimestamp,
     namespace: metadata.namespace
 }
@@ -19,6 +20,7 @@ CLUSTER_TABLE_FORMAT = """\
 CLUSTERS_LIST_TABLE_FORMAT = """\
 items[].{
     name: metadata.name,
+    phase: status.phase,
     created: metadata.creationTimestamp,
     namespace: metadata.namespace
 }

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -273,7 +273,7 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         raise UnclassifiedUserFault(err)
 
     # write the kubeconfig for the workload cluster to a file
-    # TODO: retry this operation several times, then give up and just print the command
+    # Retry this operation several times, then give up and just print the command
     delay = 10
     hook = cmd.cli_ctx.get_progress_controller(True)
     msg = "Waiting for kubeconfig to become available "


### PR DESCRIPTION
**Description**

Adds the "phase" column to `az capi show|list -o table`, similar to `kubectl get clusters -o table`.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
