### PR TITLE
Add user confirmation to several commands

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -41,7 +41,7 @@ logger = get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def init_environment(cmd, prompt=True):
-    check_preqreqs(cmd, install=True)
+    check_prereqs(cmd, install=True)
     # Create a management cluster if needed
     try:
         find_management_cluster_retry(cmd.cli_ctx)
@@ -114,7 +114,7 @@ def _install_capz_components():
 
 def create_management_cluster(cmd):
     # TODO: add user confirmation
-    check_preqreqs(cmd)
+    check_prereqs(cmd)
 
     command = ["clusterctl", "init", "--infrastructure", "azure"]
     try:
@@ -190,8 +190,8 @@ def update_management_cluster(cmd, yes=False):
     msg = 'Do you want to update CAPZ management components on the current cluster?'
     if not yes and not prompt_y_n(msg, default="n"):
         return
-    # Check for local prerequisites
-    check_preqreqs(cmd)
+    # Check for clusterctl tool
+    check_prereqs(cmd, install=yes)
     command = [
         "clusterctl",
         "upgrade",
@@ -428,19 +428,27 @@ def update_workload_cluster(cmd, capi_name):
     raise NotImplementedError
 
 
-def check_preqreqs(cmd, install=False):
+def check_prereqs(cmd, install=False):
     # Install kubectl
     if not which("kubectl") and install:
         install_kubectl(cmd)
 
     # Install clusterctl
-    if not which("clusterctl") and install:
-        install_clusterctl(cmd)
+    if not which("kubectl") and install:
+        install_kubectl(cmd)
+    # check_clusterctl(cmd, install)
 
     # Check for required environment variables
     # TODO: remove this when AAD Pod Identity becomes the default
     for var in ["AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_SUBSCRIPTION_ID", "AZURE_TENANT_ID"]:
         check_environment_var(var)
+
+
+def check_clusterctl(cmd, install=False):
+    if not which("clusterctl"):
+        logger.warn("clusterctl was not found.")
+        if install or prompt_y_n("Download and install clusterctl?", default="n"):
+            install_clusterctl(cmd)
 
 
 def check_environment_var(var):

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -446,7 +446,7 @@ def check_prereqs(cmd, install=False):
 
 def check_clusterctl(cmd, install=False):
     if not which("clusterctl"):
-        logger.warn("clusterctl was not found.")
+        logger.warning("clusterctl was not found.")
         if install or prompt_y_n("Download and install clusterctl?", default="n"):
             install_clusterctl(cmd)
 

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -60,12 +60,11 @@ class CapiScenarioTest(ScenarioTest):
 
         # Test that --yes skips confirmation and the cluster is deleted
         with patch('subprocess.check_output') as mock:
-            with patch('azext_capi.custom.check_prereqs'):
-              self.cmd("capi delete --name testcluster1 --yes", checks=[
-                  self.is_empty(),
-              ])
-              self.assertTrue(mock.called)
-              self.assertEqual(mock.call_args[0][0], ["kubectl", "delete", "cluster", "testcluster1"])
+            self.cmd("capi delete --name testcluster1 --yes", checks=[
+                self.is_empty(),
+            ])
+            self.assertTrue(mock.called)
+            self.assertEqual(mock.call_args[0][0], ["kubectl", "delete", "cluster", "testcluster1"])
 
     @patch('azext_capi.custom.exit_if_no_management_cluster')
     def test_capi_management_delete(self, mock_def):
@@ -90,11 +89,12 @@ class CapiScenarioTest(ScenarioTest):
 
         # Test that --yes skips confirmation and the cluster is updated
         with patch('subprocess.check_output') as mock:
-            self.cmd("capi management update --yes", checks=[
-                self.is_empty(),
-            ])
-            self.assertEqual(mock.call_count, 1)
-            self.assertEqual(mock.call_args_list[0][0][0][:3], ["clusterctl", "upgrade", "apply"])
+            with patch('azext_capi.custom.check_prereqs'):
+                self.cmd("capi management update --yes", checks=[
+                    self.is_empty(),
+                ])
+                self.assertEqual(mock.call_count, 1)
+                self.assertEqual(mock.call_args_list[0][0][0][:3], ["clusterctl", "upgrade", "apply"])
 
 
 AZ_CAPI_LIST_JSON = """\

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -60,11 +60,12 @@ class CapiScenarioTest(ScenarioTest):
 
         # Test that --yes skips confirmation and the cluster is deleted
         with patch('subprocess.check_output') as mock:
-            self.cmd("capi delete --name testcluster1 --yes", checks=[
-                self.is_empty(),
-            ])
-            self.assertTrue(mock.called)
-            self.assertEqual(mock.call_args.args[0], ["kubectl", "delete", "cluster", "testcluster1"])
+            with patch('azext_capi.custom.check_prereqs'):
+              self.cmd("capi delete --name testcluster1 --yes", checks=[
+                  self.is_empty(),
+              ])
+              self.assertTrue(mock.called)
+              self.assertEqual(mock.call_args[0][0], ["kubectl", "delete", "cluster", "testcluster1"])
 
     @patch('azext_capi.custom.exit_if_no_management_cluster')
     def test_capi_management_delete(self, mock_def):
@@ -78,8 +79,8 @@ class CapiScenarioTest(ScenarioTest):
                 self.is_empty(),
             ])
             self.assertEqual(mock.call_count, 2)
-            self.assertEqual(mock.call_args_list[0].args[0], ["clusterctl", "delete", "--all", "--include-crd", "--include-namespace"])
-            self.assertEqual(mock.call_args_list[1].args[0][:4], ["kubectl", "delete", "namespace", "--ignore-not-found"])
+            self.assertEqual(mock.call_args_list[0][0][0], ["clusterctl", "delete", "--all", "--include-crd", "--include-namespace"])
+            self.assertEqual(mock.call_args_list[1][0][0][:4], ["kubectl", "delete", "namespace", "--ignore-not-found"])
 
     @patch('azext_capi.custom.exit_if_no_management_cluster')
     def test_capi_management_update(self, mock_def):
@@ -93,7 +94,7 @@ class CapiScenarioTest(ScenarioTest):
                 self.is_empty(),
             ])
             self.assertEqual(mock.call_count, 1)
-            self.assertEqual(mock.call_args_list[0].args[0][:3], ["clusterctl", "upgrade", "apply"])
+            self.assertEqual(mock.call_args_list[0][0][0][:3], ["clusterctl", "upgrade", "apply"])
 
 
 AZ_CAPI_LIST_JSON = """\


### PR DESCRIPTION
**Description**

Add user confirmation to `az capi management delete|update` and `az capi delete` by default. The `--yes|-y` flag can be used to skip it.

Fixes #33

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
