### PR TITLE
Rework UX for "az aks create" as a checklist

### DIFF
--- a/src/capi/HISTORY.rst
+++ b/src/capi/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.3
+++++++
+* Rework UX for `az capi create` as a checklist
+
 0.0.2
 ++++++
 * Improve `az capi create` with status, kubeconfig, and --yes flag


### PR DESCRIPTION
**Description**

Captures stdout/stderr from wrapped command tools and replaces with a high-level summary of tasks with indeterminate progress spinners.

Fixes #30 

For example:

```shell
% az capi create -n testcluster1 -l southcentralus -y                     
Command group 'capi' is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus
✓ Generated workload cluster configuration at "testcluster1.yaml"
✓ Downloaded kubectl
✓ Downloaded clusterctl
✓ Downloaded kind
✓ Created local management cluster "capi-manager"
✓ Initialized management cluster
✓ Created workload cluster "testcluster1"
✓ Workload cluster is accessible
✓ Workload access configuration written to "testcluster1.kubeconfig"
✓ Deployed CNI to workload cluster
✓ Workload cluster is ready
{
  "apiVersion": "cluster.x-k8s.io/v1alpha3",
  "kind": "Cluster",
  "metadata": {
    "annotations": {
      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cluster.x-k8s.io/v1alpha3\",\"kind\":\"Cluster\",\"metadata\":{\"annotations\":{},\"labels\":{\"cni\":\"calico\"},\"name\":\"testcluster1\",\"namespace\":\"default\"},\"spec\":{\"clusterNetwork\":{\"pods\":{\"cidrBlocks\":[\"192.168.0.0/16\"]}},\"controlPlaneRef\":{\"apiVersion\":\"controlplane.cluster.x-k8s.io/v1alpha3\",\"kind\":\"KubeadmControlPlane\",\"name\":\"testcluster1-control-plane\"},\"infrastructureRef\":{\"apiVersion\":\"infrastructure.cluster.x-k8s.io/v1alpha3\",\"kind\":\"AzureCluster\",\"name\":\"testcluster1\"}}}\n"
    },
    "creationTimestamp": "2021-04-30T20:36:48Z",
    "finalizers": [
      "cluster.cluster.x-k8s.io"
    ],
    "generation": 2,
    "labels": {
      "cni": "calico"
    },
    "name": "testcluster1",
    "namespace": "default",
    "resourceVersion": "2726",
    "uid": "61036aa2-690d-4b5c-8ca8-fdb4645f646b"
  },
  "spec": {
    "clusterNetwork": {
      "pods": {
        "cidrBlocks": [
          "192.168.0.0/16"
        ]
      }
    },
    "controlPlaneEndpoint": {
      "host": "testcluster1-4ea828b6.southcentralus.cloudapp.azure.com",
      "port": 6443
    },
    "controlPlaneRef": {
      "apiVersion": "controlplane.cluster.x-k8s.io/v1alpha3",
      "kind": "KubeadmControlPlane",
      "name": "testcluster1-control-plane",
      "namespace": "default"
    },
    "infrastructureRef": {
      "apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
      "kind": "AzureCluster",
      "name": "testcluster1",
      "namespace": "default"
    }
  },
  "status": {
    "conditions": [
      {
        "lastTransitionTime": "2021-04-30T20:41:07Z",
        "status": "True",
        "type": "Ready"
      },
      {
        "lastTransitionTime": "2021-04-30T20:41:07Z",
        "status": "True",
        "type": "ControlPlaneReady"
      },
      {
        "lastTransitionTime": "2021-04-30T20:38:04Z",
        "status": "True",
        "type": "InfrastructureReady"
      }
    ],
    "controlPlaneInitialized": true,
    "failureDomains": {
      "1": {
        "controlPlane": true
      },
      "2": {
        "controlPlane": true
      },
      "3": {
        "controlPlane": true
      }
    },
    "infrastructureReady": true,
    "observedGeneration": 2,
    "phase": "Provisioned"
  }
}

```

**History Notes**

az capi create: Rework UX as a checklist

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
