### PR TITLE
change package loader from dynamic name to static string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # VS Code debug configuration
 .vscode/launch.json
+
+# Pycharm project configuration
+.idea

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -236,7 +236,7 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         output_path=None,
         yes=False):
     # Generate the cluster configuration
-    env = Environment(loader=PackageLoader(__name__, "templates"), auto_reload=False)
+    env = Environment(loader=PackageLoader("azext_capi", "templates"), auto_reload=False)
     logger.debug("Available templates: %s", env.list_templates())
     template = env.get_template("base.jinja")
 


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**
PackageLoader was blowing up trying to find "azext_capi.custom" rather than "azext_capi". I've just change the loader to use a static string rather than `__name__`.

```
$ az capi create -n foo
Command group 'capi' is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus
The command failed with an unexpected error. Here is the traceback:
The 'azext_capi.custom' package was not installed in a way that PackageLoader understands.
Traceback (most recent call last):
  File "/home/david/code/azure/azure-capi-cli-extension/venv/lib/python3.9/site-packages/knack/cli.py", line 231, in invoke
    cmd_result = self.invocation.execute(args)
  File "/home/david/code/azure/azure-capi-cli-extension/venv/lib/python3.9/site-packages/azure/cli/core/commands/__init__.py", line 657, in execute
    raise ex
  File "/home/david/code/azure/azure-capi-cli-extension/venv/lib/python3.9/site-packages/azure/cli/core/commands/__init__.py", line 720, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/home/david/code/azure/azure-capi-cli-extension/venv/lib/python3.9/site-packages/azure/cli/core/commands/__init__.py", line 691, in _run_job
    result = cmd_copy(params)
  File "/home/david/code/azure/azure-capi-cli-extension/venv/lib/python3.9/site-packages/azure/cli/core/commands/__init__.py", line 328, in __call__
    return self.handler(*args, **kwargs)
  File "/home/david/code/azure/azure-capi-cli-extension/venv/lib/python3.9/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
    return op(**command_args)
  File "/home/david/code/azure/azure-capi-cli-extension/src/capi/azext_capi/custom.py", line 239, in create_workload_cluster
    env = Environment(loader=PackageLoader(__name__, "templates"), auto_reload=False)
  File "/home/david/code/azure/azure-capi-cli-extension/venv/lib/python3.9/site-packages/jinja2/loaders.py", line 311, in __init__
    raise ValueError(
ValueError: The 'azext_capi.custom' package was not installed in a way that PackageLoader understands
```

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
