### PR TITLE
Fix unit tests when default az output isn't JSON

### DIFF
--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -59,7 +59,7 @@ class CapiScenarioTest(ScenarioTest):
                 self.check('items[1].metadata.name', 'testcluster2'),
             ])
 
-            count = len(self.cmd("capi list").get_output_in_json())
+            count = len(self.cmd("capi list --output json").get_output_in_json())
             self.assertEqual(count, 4)  # "apiVersion", "items", "kind", and "metadata".
 
             self.assertEqual(mock.call_count, 2)
@@ -77,7 +77,7 @@ class CapiScenarioTest(ScenarioTest):
                 self.check('metadata.name', 'testcluster1'),
             ])
 
-            count = len(self.cmd("capi show --name testcluster1").get_output_in_json())
+            count = len(self.cmd("capi show --name testcluster1 --output json").get_output_in_json())
             self.assertEqual(count, 5)  # "apiVersion", "kind", "metadata", "spec", and "status"
 
             self.assertEqual(mock.call_count, 2)


### PR DESCRIPTION
**Description**

Adds an explicit `--output json` argument to `az` commands in unit tests, so they succeed even if `~/.azure/config` specifies a different default output format.

**History Notes**

N/A

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
