### PR TITLE
Fix a spinner exit bug

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -463,7 +463,7 @@ class Spinner():
         self._controller.end(**kwargs)
 
     def tick(self):
-        if not is_verbose() and not self._controller.reporter.closed:
+        if not is_verbose() and self._controller.is_running():
             Timer(0.25, self.tick).start()
             self.update()
 
@@ -478,6 +478,7 @@ class Spinner():
     def __exit__(self, _type, value, traceback):
         if traceback:
             logger.debug(traceback)
+            self._controller.end()
         else:
             self._controller.end(message=self.end_msg)
             logger.warning(self.end_msg)


### PR DESCRIPTION
**Description**

The command-line spinner animation wasn't exiting cleanly in the case where an error was raised. This fixes that.

**History Notes**

N/A

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
