### PR TITLE
Add two variables that weren't being templated

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -248,9 +248,11 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         "AZURE_SSH_PUBLIC_KEY_B64": ssh_public_key,
         "AZURE_VNET_NAME": vnet_name,
         "CLUSTER_NAME": capi_name,
+        "CONTROL_PLANE_MACHINE_COUNT": control_plane_machine_count,
         "KUBERNETES_VERSION": kubernetes_version,
         "EPHEMERAL": ephemeral_disks,
         "WINDOWS": windows,
+        "WORKER_MACHINE_COUNT": node_machine_count,
         "NODEPOOL_TYPE": "machinepool" if machinepool else "machinedeployment",
     }
     filename = capi_name + ".yaml"


### PR DESCRIPTION
**Description**

When I was looking at `custom.py`, the VS Code highlighter showed me two arguments to `create_workload_cluster` that were unused but should have been passed through to the Jinja templates. This fixes that.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
