### PR TITLE
Updated create management cluster method

### DIFF
--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import subprocess
 import os
 import unittest
 from unittest.mock import MagicMock, Mock, patch
@@ -10,13 +11,14 @@ from unittest.mock import MagicMock, Mock, patch
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.core.azclierror import InvalidArgumentValueError
 from azure.cli.core.azclierror import UnclassifiedUserFault
+from azure.cli.core.azclierror import ResourceNotFoundError
 from azure.cli.core.azclierror import RequiredArgumentMissingError
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 from knack.prompting import NoTTYException
 from msrestazure.azure_exceptions import CloudError
 
 
-from azext_capi.custom import try_command_with_spinner
+from azext_capi.custom import create_new_management_cluster, find_cluster_in_current_context, find_kubectl_current_context, run_shell_command, try_command_with_spinner, _find_default_cluster
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -142,6 +144,83 @@ class CommandGenericTest(unittest.TestCase):
         with self.assertRaises(UnclassifiedUserFault) as cm:
             try_command_with_spinner(cmd, ["fake-command"], "begin", "end", error_msg)
         self.assertEquals(cm.exception.error_msg, error_msg)
+
+    @patch('azext_capi.custom.check_cmd')
+    def test_find_default_cluster(self, check_cmd_mock):
+        check_cmd_mock.return_value = "fake return"
+        # Test kubernetes cluster is found and running
+        result = _find_default_cluster()
+        check_cmd_mock.assert_called_once()
+        self.assertTrue(result)
+        # Test kubernetes cluster is found but not running state matched
+        check_cmd_mock.return_value = None
+        with self.assertRaises(ResourceNotFoundError):
+            _find_default_cluster()
+        # Test error with command ran
+        check_cmd_mock.side_effect = subprocess.CalledProcessError(3, ['fakecommand'])
+        with self.assertRaises(subprocess.CalledProcessError):
+            _find_default_cluster()
+
+    @patch('azext_capi.custom.try_command_with_spinner')
+    @patch('azext_capi.custom.prompt_choice_list')
+    def test_create_new_management_cluster(self, promp_mock, try_spinner_mock):
+        # Test exit after user input is >= 2
+        cmd = Mock()
+        promp_mock.return_value = 2
+        result = create_new_management_cluster(cmd)
+        self.assertFalse(result)
+        # Test create local kind management cluster
+        promp_mock.return_value = 1
+        with patch('azext_capi.custom.check_kind'):
+            result = create_new_management_cluster(cmd)
+            self.assertTrue(result)
+        # Test create AKS management cluster
+        promp_mock.return_value = 0
+        with patch('azext_capi.custom.Spinner'):
+            with patch('azext_capi.custom.subprocess.check_call'):
+                result = create_new_management_cluster(cmd)
+                self.assertTrue(result)
+
+    def test_run_shell_command(self):
+        command = ["fake-command"]
+        with patch('subprocess.check_output') as mock:
+            run_shell_command(command)
+            mock.assert_called_once()
+        with self.assertRaises(FileNotFoundError):
+            run_shell_command(command)
+
+    @patch('azext_capi.custom.run_shell_command')
+    def test_find_kubectl_current_context(self, run_shell_mock):
+        # Test found current context
+        context_name = "fake-context"
+        run_shell_mock.return_value = context_name
+        result = find_kubectl_current_context()
+        self.assertEquals(result, context_name)
+        # Test found current context with extra space
+        context_name = "fake-context"
+        run_shell_mock.return_value = f"  {context_name}  "
+        result = find_kubectl_current_context()
+        self.assertEquals(result, context_name)
+        # Test does not found current context
+        run_shell_mock.return_value = None
+        run_shell_mock.side_effect = subprocess.CalledProcessError(3, ['fakecommand'])
+        result = find_kubectl_current_context()
+        self.assertIsNone(result)
+
+    @patch('azext_capi.custom.run_shell_command')
+    def test_find_cluster_in_current_context(self, run_shell_mock):
+        # Test found current cluster in context
+        context_name = "context-name-fake"
+        cluster_name = "cluster-name-fake"
+        context_info = f"* {context_name} {cluster_name}"
+        run_shell_mock.return_value = context_info
+        result = find_cluster_in_current_context(context_name)
+        self.assertEquals(result, cluster_name)
+        # Test does not found current context
+        run_shell_mock.return_value = None
+        run_shell_mock.side_effect = subprocess.CalledProcessError(3, ['fakecommand'])
+        result = find_cluster_in_current_context(context_name)
+        self.assertIsNone(result)
 
 
 AZ_CAPI_LIST_JSON = """\


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**
The current method `az capi management create` to create a management cluster only works if there is an existent k8s cluster and installing the required capz components.

The update aims to allow user to decide if they want to use existing cluster aa a management cluster or to create a management cluster from scratch.

User scenarios:
1. User decides to use existing cluster as a management cluster, we check if we have access to the cluster and proceed to install capz components.
2. User selects to create cluster from scratch, they have the option to create a local (kind) or AKS cluster.

The logic for prompting the user and creating management is extracted to a helper method as it can be reused in `az capi create` when we need to create a management cluster 
 
**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
