### PR TITLE
handle resource group errors and create it

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -295,7 +295,7 @@ def update_management_cluster(cmd, yes=False):
 
 
 def create_resource_group(cmd, rg_name, location, yes=False):
-    msg = f"Do you want to create, an Azure resource group named {rg_name} located: {location}?"
+    msg = f'Create the Azure resource group "{rg_name}" in location "{location}"?'
     if yes or prompt_y_n(msg, default="n"):
         command = ["az", "group", "create", "-l", location, "-n", rg_name]
         begin_msg = f"Creating Resource Group: {rg_name}"

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -21,6 +21,7 @@ from azext_capi.custom import create_resource_group, create_new_management_clust
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
+
 class CapiScenarioTest(ScenarioTest):
 
     @patch('azext_capi.custom.exit_if_no_management_cluster')

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import subprocess
 import os
 import unittest
 from unittest.mock import MagicMock, Mock, patch
@@ -16,7 +17,7 @@ from knack.prompting import NoTTYException
 from msrestazure.azure_exceptions import CloudError
 
 
-from azext_capi.custom import try_command_with_spinner
+from azext_capi.custom import create_resource_group, try_command_with_spinner
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -142,6 +143,19 @@ class CommandGenericTest(unittest.TestCase):
         with self.assertRaises(UnclassifiedUserFault) as cm:
             try_command_with_spinner(cmd, ["fake-command"], "begin", "end", error_msg)
         self.assertEquals(cm.exception.error_msg, error_msg)
+
+    @patch('azext_capi.custom.try_command_with_spinner')
+    def test_create_resource_group(self, mock_try_command):
+        # Test created new resource group
+        cmd = Mock()
+        group = "fake-resource-group"
+        location = "fake-location"
+        result = create_resource_group(cmd, group, location, True)
+        self.assertTrue(result)
+        # Test Error creating resource group
+        mock_try_command.side_effect = subprocess.CalledProcessError(3, ['fakecommand'])
+        with self.assertRaises(subprocess.CalledProcessError):
+            create_resource_group(cmd, group, location, True)
 
 
 AZ_CAPI_LIST_JSON = """\


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

PR aims to: 
1. Extract logic to create a resource group, so it can be reused when need to create Azure Resource Group.
2. On the create workload cluster method, updates the way to handle case where we fetch for not existing resource group and will raise an exception that we were not properly catching and will try to create Azure Resource Group.

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
