### PR TITLE
Allow custom naming a management cluster

### DIFF
--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -47,6 +47,9 @@ parameters:
   - name: --machinepool
     type: bool
     short-summary: Use experimental MachinePools instead of MachineSets
+  - name: --management-cluster-name
+    type: string
+    short-summary: Name for management cluster.
   - name: --node-machine-count
     type: integer
   - name: --node-machine-type
@@ -108,6 +111,10 @@ long-summary: |
 helps['capi management create'] = """
 type: command
 short-summary: Create a CAPI management cluster.
+parameters:
+  - name: --cluster-name
+    type: string
+    short-summary: Name for management cluster.
 """
 
 helps['capi management delete'] = """

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -31,6 +31,7 @@ from jinja2 import Environment, PackageLoader, StrictUndefined
 from jinja2.exceptions import UndefinedError
 from knack.log import get_logger
 from knack.prompting import prompt_choice_list, prompt_y_n
+from knack.prompting import prompt as prompt_method
 from msrestazure.azure_exceptions import CloudError
 from six.moves.urllib.request import urlopen  # pylint: disable=import-error
 
@@ -46,7 +47,7 @@ def is_verbose():
     return any(handler.level <= logging.INFO for handler in logger.handlers)
 
 
-def init_environment(cmd, prompt=True):
+def init_environment(cmd, prompt=True, management_cluster_name=None):
     check_prereqs(cmd, install=True)
     # Create a management cluster if needed
     try:
@@ -62,7 +63,7 @@ Cluster API needs a "management cluster" to run its components.
 Learn more from the Cluster API Book:
 https://cluster-api.sigs.k8s.io/user/concepts.html
 """
-        if not create_new_management_cluster(cmd, prompt, pre_prompt):
+        if not create_new_management_cluster(cmd, prompt, pre_prompt, cluster_name=management_cluster_name):
             return False
         _create_azure_identity_secret(cmd)
         _install_capz_components(cmd)
@@ -152,7 +153,7 @@ def find_cluster_to_become_management_cluster():
     return cluster_name
 
 
-def create_management_cluster(cmd, yes=False):
+def create_management_cluster(cmd, cluster_name=None, yes=False):
     check_prereqs(cmd)
     existing_cluster = find_cluster_to_become_management_cluster()
     found_cluster = False
@@ -164,27 +165,44 @@ def create_management_cluster(cmd, yes=False):
                 found_cluster = True
             except subprocess.CalledProcessError as err:
                 raise UnclassifiedUserFault("Can't locate a Kubernetes cluster") from err
-    if not found_cluster and not create_new_management_cluster(cmd):
+    if not found_cluster and not create_new_management_cluster(cmd, cluster_name=cluster_name):
         return
     set_azure_identity_secret_env_vars()
     _create_azure_identity_secret(cmd)
     _install_capz_components(cmd)
 
 
-def create_new_management_cluster(cmd, prompt=True, pre_prompt_text=None):
+def get_cluster_name_by_user_prompt(default_name):
+    prompt = f"Please name the management cluster [Default {default_name}]: "
+    while True:
+        prompt_res = prompt_method(prompt)
+        prompt_res = prompt_res.strip()
+        if prompt_res == "":
+            return None
+        if re.match("^[a-z0-9.-]+$", prompt_res):
+            return prompt_res
+        msg = "Invalid name for cluster: only lowercase characters, numbers, dashes and periods allowed"
+        logger.error(msg)
+
+
+def create_new_management_cluster(cmd, prompt=True, pre_prompt_text=None, cluster_name=None):
     choices = ["azure - a management cluster in the Azure cloud",
                "local - a local Docker container-based management cluster",
                "exit - don't create a management cluster"]
 
+    default_cluster_name = "capi-manager"
     if prompt:
         prompt = pre_prompt_text if pre_prompt_text else ""
         prompt += """
 Where do you want to create a management cluster?
 """
         choice_index = prompt_choice_list(prompt, choices)
+        cluster_name = get_cluster_name_by_user_prompt(default_cluster_name)
+        if not cluster_name:
+            cluster_name = default_cluster_name
     else:
+        cluster_name = default_cluster_name
         choice_index = 0
-    cluster_name = "capi-manager"
     if choice_index == 0:
         command = ["az", "group", "create", "-l", "southcentralus", "--name", cluster_name]
         try_command_with_spinner(cmd, command, "Creating Azure resource group", "✓ Created Azure resource group",
@@ -316,6 +334,7 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         subscription_id=os.environ.get("AZURE_SUBSCRIPTION_ID"),
         ssh_public_key=os.environ.get("AZURE_SSH_PUBLIC_KEY_B64", ""),
         external_cloud_provider=False,
+        management_cluster_name=None,
         vnet_name=None,
         machinepool=False,
         ephemeral_disks=False,
@@ -351,7 +370,7 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
     # Set Azure Identity Secret enviroment variables. This will be used in init_environment
     set_azure_identity_secret_env_vars()
 
-    if not init_environment(cmd, not yes):
+    if not init_environment(cmd, not yes, management_cluster_name):
         return
 
     # Generate the cluster configuration

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -161,9 +161,11 @@ class CommandGenericTest(unittest.TestCase):
         with self.assertRaises(subprocess.CalledProcessError):
             _find_default_cluster()
 
+    @patch('azext_capi.custom.prompt_y_n')
+    @patch('azext_capi.custom.get_cluster_name_by_user_prompt')
     @patch('azext_capi.custom.try_command_with_spinner')
     @patch('azext_capi.custom.prompt_choice_list')
-    def test_create_new_management_cluster(self, promp_mock, try_spinner_mock):
+    def test_create_new_management_cluster(self, promp_mock, try_spinner_mock, user_prompt_mock, prompt_y_n):
         # Test exit after user input is >= 2
         cmd = Mock()
         promp_mock.return_value = 2


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

This PR aims to allow users to custom name their management cluster instead of only the hardcoded name "capi-manager"
when running `az capi management create` and `az capi create`.
This is presented to the user in two options:
1. Use flag `--cluster-name` for `az capi management create` and `--management-cluster-name` for `az capi create`
2.  When a user is creating the management cluster, they will be prompt if they want to custom name the cluster or default it.

Fixes:  #71 

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
