### PR TITLE
updated exception handle of resource group finding attempt

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -24,6 +24,7 @@ from azure.cli.core.api import get_config_dir
 from azure.cli.core.azclierror import FileOperationError
 from azure.cli.core.azclierror import InvalidArgumentValueError
 from azure.cli.core.azclierror import RequiredArgumentMissingError
+from azure.core.exceptions import ResourceNotFoundError as ResourceNotFoundException
 from azure.cli.core.azclierror import ResourceNotFoundError
 from azure.cli.core.azclierror import UnclassifiedUserFault
 from azure.cli.core.azclierror import ValidationError
@@ -337,12 +338,13 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         elif location != rg.location:
             msg = "--location is {}, but the resource group {} already exists in {}."
             raise InvalidArgumentValueError(msg.format(location, resource_group_name, rg.location))
-    except CloudError as err:
+    except (CloudError, ResourceNotFoundException) as err:
         if 'could not be found' not in err.message:
             raise
         if not location:
             msg = "--location is required to create the resource group {}."
             raise RequiredArgumentMissingError(msg.format(resource_group_name)) from err
+        logger.warning("Could not find an Azure resource group, CAPZ will create one for you")
 
     msg = f'Create the Kubernetes cluster "{capi_name}" in the Azure resource group "{resource_group_name}"?'
     if not yes and not prompt_y_n(msg, default="n"):


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

This PR aims to fix an exception not being caught when we fetch for a not existing resource group in `az capi create` method

The supposed behavior is intended to look for a resource group if user specifies one with flag `-g or --resource-group` or allow CAPZ create one when it is needed.

At the moment if the group is not found it will raise an exception that is not handle and therefore the process is terminated.

Fixes #68
**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
