### PR TITLE
Update UX of creating Aks management cluster 

### DIFF
--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -47,6 +47,9 @@ parameters:
   - name: --machinepool
     type: bool
     short-summary: Use experimental MachinePools instead of MachineSets
+  - name: --management-cluster-name
+    type: string
+    short-summary: Name for management cluster.
   - name: --node-machine-count
     type: integer
   - name: --node-machine-type
@@ -108,6 +111,10 @@ long-summary: |
 helps['capi management create'] = """
 type: command
 short-summary: Create a CAPI management cluster.
+parameters:
+  - name: --cluster-name
+    type: string
+    short-summary: Name for management cluster.
 """
 
 helps['capi management delete'] = """

--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -37,6 +37,9 @@ def load_arguments(self, _):
         ctx.argument('vnet_name', options_list=['--vnet-name'])
         ctx.argument('windows', options_list=['--windows', '-w'])
         ctx.argument('yes', options_list=['--yes', '-y'], help="Do not prompt for confirmation")
+        ctx.argument('management_cluster_resource_group_name',
+                     options_list=['--management-cluster-resource-group-name', '-mg'],
+                     help="Resource group name of management cluster")
 
 
 def get_virtualenv():

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -31,6 +31,7 @@ from jinja2 import Environment, PackageLoader, StrictUndefined
 from jinja2.exceptions import UndefinedError
 from knack.log import get_logger
 from knack.prompting import prompt_choice_list, prompt_y_n
+from knack.prompting import prompt as prompt_method
 from msrestazure.azure_exceptions import CloudError
 from six.moves.urllib.request import urlopen  # pylint: disable=import-error
 
@@ -46,7 +47,7 @@ def is_verbose():
     return any(handler.level <= logging.INFO for handler in logger.handlers)
 
 
-def init_environment(cmd, prompt=True):
+def init_environment(cmd, prompt=True, management_cluster_name=None):
     check_prereqs(cmd, install=True)
     # Create a management cluster if needed
     try:
@@ -62,7 +63,7 @@ Cluster API needs a "management cluster" to run its components.
 Learn more from the Cluster API Book:
 https://cluster-api.sigs.k8s.io/user/concepts.html
 """
-        if not create_new_management_cluster(cmd, prompt, pre_prompt):
+        if not create_new_management_cluster(cmd, prompt, pre_prompt, cluster_name=management_cluster_name):
             return False
         _create_azure_identity_secret(cmd)
         _install_capz_components(cmd)
@@ -152,7 +153,7 @@ def find_cluster_to_become_management_cluster():
     return cluster_name
 
 
-def create_management_cluster(cmd, yes=False):
+def create_management_cluster(cmd, cluster_name=None, yes=False):
     check_prereqs(cmd)
     existing_cluster = find_cluster_to_become_management_cluster()
     found_cluster = False
@@ -164,27 +165,44 @@ def create_management_cluster(cmd, yes=False):
                 found_cluster = True
             except subprocess.CalledProcessError as err:
                 raise UnclassifiedUserFault("Can't locate a Kubernetes cluster") from err
-    if not found_cluster and not create_new_management_cluster(cmd):
+    if not found_cluster and not create_new_management_cluster(cmd, cluster_name=cluster_name):
         return
     set_azure_identity_secret_env_vars()
     _create_azure_identity_secret(cmd)
     _install_capz_components(cmd)
 
 
-def create_new_management_cluster(cmd, prompt=True, pre_prompt_text=None):
+def get_cluster_name_by_user_prompt(default_name):
+    prompt = f"Please name the management cluster [Default {default_name}]: "
+    while True:
+        prompt_res = prompt_method(prompt)
+        prompt_res = prompt_res.strip()
+        if prompt_res == "":
+            return None
+        if re.match("^[a-z0-9.-]+$", prompt_res):
+            return prompt_res
+        msg = "Invalid name for cluster: only lowercase characters, numbers, dashes and periods allowed"
+        logger.error(msg)
+
+
+def create_new_management_cluster(cmd, prompt=True, pre_prompt_text=None, cluster_name=None):
     choices = ["azure - a management cluster in the Azure cloud",
                "local - a local Docker container-based management cluster",
                "exit - don't create a management cluster"]
 
+    default_cluster_name = "capi-manager"
     if prompt:
         prompt = pre_prompt_text if pre_prompt_text else ""
         prompt += """
 Where do you want to create a management cluster?
 """
         choice_index = prompt_choice_list(prompt, choices)
+        cluster_name = get_cluster_name_by_user_prompt(default_cluster_name)
+        if not cluster_name:
+            cluster_name = default_cluster_name
     else:
+        cluster_name = default_cluster_name
         choice_index = 0
-    cluster_name = "capi-manager"
     if choice_index == 0:
         command = ["az", "group", "create", "-l", "southcentralus", "--name", cluster_name]
         try_command_with_spinner(cmd, command, "Creating Azure resource group", "✓ Created Azure resource group",
@@ -316,6 +334,7 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         subscription_id=os.environ.get("AZURE_SUBSCRIPTION_ID"),
         ssh_public_key=os.environ.get("AZURE_SSH_PUBLIC_KEY_B64", ""),
         external_cloud_provider=False,
+        management_cluster_name=None,
         vnet_name=None,
         machinepool=False,
         ephemeral_disks=False,
@@ -351,7 +370,7 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
     # Set Azure Identity Secret enviroment variables. This will be used in init_environment
     set_azure_identity_secret_env_vars()
 
-    if not init_environment(cmd, not yes):
+    if not init_environment(cmd, not yes, management_cluster_name):
         return
 
     # Generate the cluster configuration

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -47,7 +47,8 @@ def is_verbose():
     return any(handler.level <= logging.INFO for handler in logger.handlers)
 
 
-def init_environment(cmd, prompt=True, management_cluster_name=None):
+def init_environment(cmd, prompt=True, management_cluster_name=None,
+                     resource_group_name=None, location=None):
     check_prereqs(cmd, install=True)
     # Create a management cluster if needed
     try:
@@ -63,7 +64,9 @@ Cluster API needs a "management cluster" to run its components.
 Learn more from the Cluster API Book:
 https://cluster-api.sigs.k8s.io/user/concepts.html
 """
-        if not create_new_management_cluster(cmd, prompt, pre_prompt, cluster_name=management_cluster_name):
+        if not create_new_management_cluster(cmd, management_cluster_name,
+                                             resource_group_name, location,
+                                             pre_prompt_text=pre_prompt, prompt=prompt):
             return False
         _create_azure_identity_secret(cmd)
         _install_capz_components(cmd)
@@ -153,7 +156,20 @@ def find_cluster_to_become_management_cluster():
     return cluster_name
 
 
-def create_management_cluster(cmd, cluster_name=None, yes=False):
+def create_resource_group(cmd, rg_name, location, yes=False):
+    msg = f'Create the Azure resource group "{rg_name}" in location "{location}"?'
+    if yes or prompt_y_n(msg, default="n"):
+        command = ["az", "group", "create", "-l", location, "-n", rg_name]
+        begin_msg = f"Creating Resource Group: {rg_name}"
+        end_msg = f"✓ Created Resource Group: {rg_name}"
+        err_msg = f"Could not create resource group {rg_name}"
+        try_command_with_spinner(cmd, command, begin_msg, end_msg, err_msg)
+        return True
+    return False
+
+
+def create_management_cluster(cmd, cluster_name=None, resource_group_name=None, location=None,
+                              yes=False):
     check_prereqs(cmd)
     existing_cluster = find_cluster_to_become_management_cluster()
     found_cluster = False
@@ -165,7 +181,8 @@ def create_management_cluster(cmd, cluster_name=None, yes=False):
                 found_cluster = True
             except subprocess.CalledProcessError as err:
                 raise UnclassifiedUserFault("Can't locate a Kubernetes cluster") from err
-    if not found_cluster and not create_new_management_cluster(cmd, cluster_name=cluster_name):
+    if not found_cluster and not create_new_management_cluster(cmd, cluster_name, resource_group_name,
+                                                               location, prompt=not yes):
         return
     set_azure_identity_secret_env_vars()
     _create_azure_identity_secret(cmd)
@@ -173,50 +190,78 @@ def create_management_cluster(cmd, cluster_name=None, yes=False):
 
 
 def get_cluster_name_by_user_prompt(default_name):
-    prompt = f"Please name the management cluster [Default {default_name}]: "
+    prompt = "Please name the management cluster"
+    regex_validator = "^[a-z0-9.-]+$"
+    invalid_msg = "Invalid name for cluster: only lowercase characters, numbers, dashes and periods allowed"
+    return get_user_prompt_or_default(prompt, default_name, regex_validator, invalid_msg)
+
+
+def get_user_prompt_or_default(prompt_text, default_value, match_expression=None,
+                               invalid_prompt=None, skip_prompt=False):
+
+    if skip_prompt:
+        return default_value
+
+    prompt = f"{prompt_text} [Default {default_value}]: "
     while True:
-        prompt_res = prompt_method(prompt)
-        prompt_res = prompt_res.strip()
-        if prompt_res == "":
-            return None
-        if re.match("^[a-z0-9.-]+$", prompt_res):
-            return prompt_res
-        msg = "Invalid name for cluster: only lowercase characters, numbers, dashes and periods allowed"
-        logger.error(msg)
+        user_input = prompt_method(prompt)
+        user_input = user_input.strip()
+        if user_input == "":
+            return default_value
+        if match_expression and re.match(match_expression, user_input):
+            return user_input
+        if not match_expression:
+            return user_input
+        if invalid_prompt:
+            logger.error(invalid_prompt)
 
 
-def create_new_management_cluster(cmd, prompt=True, pre_prompt_text=None, cluster_name=None):
+def create_aks_management_cluster(cmd, cluster_name, resource_group_name=None, location=None, yes=False):
+    if not resource_group_name:
+        msg = "Please name the resource group for the management cluster"
+        resource_group_name = get_user_prompt_or_default(msg, cluster_name, skip_prompt=yes)
+    if not location:
+        default_location = "southcentralus"
+        msg = f"Please provide a location for {resource_group_name} resource group"
+        location = get_user_prompt_or_default(msg, default_location, skip_prompt=yes)
+    if not create_resource_group(cmd, resource_group_name, location, yes):
+        return False
+    command = ["az", "aks", "create", "-g", resource_group_name, "--name", cluster_name, "--generate-ssh-keys",
+               "--network-plugin", "azure", "--network-policy", "calico"]
+    try_command_with_spinner(cmd, command, "Creating Azure management cluster with AKS",
+                             "✓ Created AKS management cluster", "Couldn't create AKS management cluster")
+    with Spinner(cmd, "Obtaining AKS credentials", "✓ Obtained AKS credentials"):
+        command = ["az", "aks", "get-credentials", "-g", resource_group_name, "--name", cluster_name]
+        try:
+            subprocess.check_call(command, universal_newlines=True)
+        except subprocess.CalledProcessError as err:
+            raise UnclassifiedUserFault("Couldn't get credentials for AKS management cluster") from err
+    return True
+
+
+def create_new_management_cluster(cmd, cluster_name=None, resource_group_name=None,
+                                  location=None, pre_prompt_text=None, prompt=True):
     choices = ["azure - a management cluster in the Azure cloud",
                "local - a local Docker container-based management cluster",
                "exit - don't create a management cluster"]
 
     default_cluster_name = "capi-manager"
     if prompt:
-        prompt = pre_prompt_text if pre_prompt_text else ""
-        prompt += """
+        prompt_text = pre_prompt_text if pre_prompt_text else ""
+        prompt_text += """
 Where do you want to create a management cluster?
 """
-        choice_index = prompt_choice_list(prompt, choices)
-        cluster_name = get_cluster_name_by_user_prompt(default_cluster_name)
+        choice_index = prompt_choice_list(prompt_text, choices)
+        if choice_index != 2 and not cluster_name:
+            cluster_name = get_cluster_name_by_user_prompt(default_cluster_name)
+    else:
         if not cluster_name:
             cluster_name = default_cluster_name
-    else:
-        cluster_name = default_cluster_name
         choice_index = 0
     if choice_index == 0:
-        command = ["az", "group", "create", "-l", "southcentralus", "--name", cluster_name]
-        try_command_with_spinner(cmd, command, "Creating Azure resource group", "✓ Created Azure resource group",
-                                 "Couldn't create Azure resource group")
-        command = ["az", "aks", "create", "-g", cluster_name, "--name", cluster_name, "--generate-ssh-keys",
-                   "--network-plugin", "azure", "--network-policy", "calico"]
-        try_command_with_spinner(cmd, command, "Creating Azure management cluster with AKS",
-                                 "✓ Created AKS management cluster", "Couldn't create AKS management cluster")
-        with Spinner(cmd, "Obtaining AKS credentials", "✓ Obtained AKS credentials"):
-            command = ["az", "aks", "get-credentials", "-g", cluster_name, "--name", cluster_name]
-            try:
-                subprocess.check_call(command, universal_newlines=True)
-            except subprocess.CalledProcessError as err:
-                raise UnclassifiedUserFault("Couldn't get credentials for AKS management cluster") from err
+        if not create_aks_management_cluster(cmd, cluster_name, resource_group_name,
+                                             location, yes=not prompt):
+            return False
     elif choice_index == 1:
         check_kind(cmd, install=not prompt)
         begin_msg = f'Creating local management cluster "{cluster_name}" with kind'
@@ -335,6 +380,7 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         ssh_public_key=os.environ.get("AZURE_SSH_PUBLIC_KEY_B64", ""),
         external_cloud_provider=False,
         management_cluster_name=None,
+        management_cluster_resource_group_name=None,
         vnet_name=None,
         machinepool=False,
         ephemeral_disks=False,
@@ -370,7 +416,8 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
     # Set Azure Identity Secret enviroment variables. This will be used in init_environment
     set_azure_identity_secret_env_vars()
 
-    if not init_environment(cmd, not yes, management_cluster_name):
+    if not init_environment(cmd, not yes, management_cluster_name, management_cluster_resource_group_name,
+                            location):
         return
 
     # Generate the cluster configuration

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -161,9 +161,11 @@ class CommandGenericTest(unittest.TestCase):
         with self.assertRaises(subprocess.CalledProcessError):
             _find_default_cluster()
 
+    @patch('azext_capi.custom.prompt_y_n')
+    @patch('azext_capi.custom.get_cluster_name_by_user_prompt')
     @patch('azext_capi.custom.try_command_with_spinner')
     @patch('azext_capi.custom.prompt_choice_list')
-    def test_create_new_management_cluster(self, promp_mock, try_spinner_mock):
+    def test_create_new_management_cluster(self, promp_mock, try_spinner_mock, user_prompt_mock, prompt_y_n):
         # Test exit after user input is >= 2
         cmd = Mock()
         promp_mock.return_value = 2


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

This PR aims to cover and update, the UX of creation an Aks management cluster:
This update aims to allow user customization of Aks management cluster name, resource group name, location and resource group.
 - This is accomplished by an updated UX flow in which we prompt user for customize names or they can default it.
 - The users can also utilize new flags on methods `az capi create` & `az capi management create`  

az capi create new flags:
```
--management-cluster-name 
--management-cluster-resource-group-name -mg
```
az capi  management create new flags:
```
--cluster-name 
--location -l
--resource-group -g
```
To note that users can skip prompts for custom values by entering an empty value or by using the `--yes` flag when running the command.

Fixes #78 

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
