### PR TITLE
added pivot option for capi create

### DIFF
--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -57,6 +57,11 @@ parameters:
   - name: --output-path -p
     type: string
     short-summary: Where to save helper commands when they are downloaded
+  - name: --pivot
+    type: bool
+    short-summary: Move provider and CAPI resources to workload cluster.
+    long-summary: |
+       Learn more about pivot at https://cluster-api.sigs.k8s.io/clusterctl/commands/move.html
   - name: --resource-group -g
     type: string
     long-summary: |

--- a/src/capi/azext_capi/_helpers.py
+++ b/src/capi/azext_capi/_helpers.py
@@ -33,3 +33,11 @@ def urlretrieve(url, filename):
     req = urlopen(url, context=ssl_context())  # pylint: disable=consider-using-with
     with open(filename, "wb") as out:
         out.write(req.read())
+
+
+def add_kubeconfig_to_command(kubeconfig=None):
+    return ["--kubeconfig", kubeconfig] if kubeconfig else []
+
+
+def has_kind_prefix(inpt_str):
+    return inpt_str.startswith("kind-")


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

This PR aims to add pivot functionality to `az  capi create` with flag `--pivot`.
The current will take care of 
1. Creating a temporal bootstrap management cluster 
2. Creating a workload cluster
3. Installing Cluster API components in workload cluster
4. Waiting for components to be running
5. Proceed to move Cluster Objects from bootstrap cluster to workload cluster
6. After successfully moved the objects, we will delete temporal bootstrap cluster
7. Merge default kubeconfig with workload kubeconfig so we can continue to refence workload cluster.

***Note***: Delete management cluster, when deleting kind cluster mostly everything gets clean by `kind delete cluster` including context in kubeconfig. However, for AKS, the kubeconfig context get left behind. We are taking care of clean up for the user in this scenario.

This functionally is currently not set a default but rather an option.

Fixes #85

*History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
