### PR TITLE
Add a separate install tools command

### DIFF
--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -81,6 +81,14 @@ long-summary: |
     See https://capz.sigs.k8s.io/ for more information.
 """
 
+helps['capi install'] = """
+type: command
+short-summary: installs all needed tools
+parameters:
+  - name: --all -a
+    type: bool
+"""
+
 helps['capi show'] = """
 type: command
 short-summary: Show details of a workload cluster.

--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -41,6 +41,9 @@ def load_arguments(self, _):
                      options_list=['--management-cluster-resource-group-name', '-mg'],
                      help="Resource group name of management cluster")
 
+    with self.argument_context('capi install') as ctx:
+        ctx.argument('all_tools', capi_name_type, options_list=['--all', '-a'])
+
 
 def get_virtualenv():
     return os.getenv("VIRTUAL_ENV")

--- a/src/capi/azext_capi/commands.py
+++ b/src/capi/azext_capi/commands.py
@@ -24,6 +24,7 @@ def load_command_table(self, _):
         g.custom_command('show', 'show_workload_cluster',
                          table_transformer=CLUSTER_TABLE_FORMAT)
         g.custom_command('update', 'update_workload_cluster')
+        g.custom_command('install', 'install_tools')
 
     with self.command_group('capi management', is_preview=True) as g:
         g.custom_command('create', 'create_management_cluster')

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -783,9 +783,21 @@ def update_workload_cluster(cmd, capi_name):
     raise NotImplementedError
 
 
-def check_prereqs(cmd, install=False):
+def install_tools(cmd, all_tools=False):
+    if all_tools:
+        logger.info('Checking if required tools are installed')
+        check_tools(cmd, True)
+    else:
+        logger.info('Installing individual tools is not currently supported')
+
+
+def check_tools(cmd, install=False):
     check_kubectl(cmd, install)
     check_clusterctl(cmd, install)
+
+
+def check_prereqs(cmd, install=False):
+    check_tools(cmd, install)
 
     # Check for required environment variables
     # TODO: remove this when AAD Pod Identity becomes the default


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**
Add a separate install tools command. This allows for something like `sudo az capi install` which fixes issues when installing things on Linux.  This seems to be the pattern according to https://github.com/Azure/azure-cli/issues/2558#issuecomment-289919156

Fixes: #90 

**History Notes**

Something I tried was using a temp path in the function `download_binary` if on linux but because this command was in a spinner it never prompted (it did but it got overwritten). It worked if I had recently used sudo.

```
  if system == "Linux":
         tmpfile = Path(tempfile.gettempdir()).joinpath(os.path.basename(install_location))
        urlretrieve(file_url, tmpfile)
        os.system(f"sudo mv {tmpfile} {install_location}")
  else:
```

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
