### PR TITLE
Added an envsubst function

### DIFF
--- a/src/capi/azext_capi/envsubst.py
+++ b/src/capi/azext_capi/envsubst.py
@@ -1,0 +1,56 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+Substitutes environment variables in shell-formatted strings.
+
+>>> envsubst('${var}', {'var': 'value'})
+'value'
+"""
+
+import os
+import re
+
+
+def envsubst(s, env):
+    """Substitutes environment variables in shell-formatted strings."""
+    # ${var,,} -> lowercase all characters of variable
+    s = re.sub(r'\$\{([^{}]+),,\}', lambda m: env[m.group(1)].lower(), s)
+    # ${var,} -> lowercase first character of variable
+    s = re.sub(r'\$\{([^{}]+),\}', lambda m: env[m.group(1)][:1].lower() + env[m.group(1)][1:], s)
+    # ${var^^} -> uppercase all characters of variable
+    s = re.sub(r'\$\{([^{}]+)\^\^\}', lambda m: env[m.group(1)].upper(), s)
+    # ${var^} -> uppercase first character of variable
+    s = re.sub(r'\$\{([^{}]+)\^\}', lambda m: env[m.group(1)][:1].upper() + env[m.group(1)][1:], s)
+    # ${#var} -> string length of variable
+    s = re.sub(r'\$\{#([^{}]+)\}', lambda m: str(len(env[m.group(1)])), s)
+    # ${var:pos} -> value of variable from a string position to end
+    s = re.sub(r'\$\{([^{}:]+):([^{}:=-]+)\}', lambda m: env[m.group(1)][int(m.group(2)):], s)
+    # ${var:pos:len} -> value of variable from a string position with max length
+    s = re.sub(r'\$\{([^{}:]+):([^{}:=-]+):([^{}:=-]+)\}',
+               lambda m: env[m.group(1)][int(m.group(2)):int(m.group(2)) + int(m.group(3))], s)
+    # ${var} -> simple value of variable
+    s = re.sub(r'\$\{([^{}:=-]+)\}', lambda m: env[m.group(1)], s)
+    # ${var:=default} -> evaluate default expression if variable is not set or empty
+    s = re.sub(r'\$\{([^}]+):[=-]([^}]+)\}', lambda m: env[m.group(1)] if env.get(m.group(1)) else m.group(2), s)
+    # ${var=default} -> evaluate default expression if variable is not set
+    s = re.sub(r'\$\{([^}]+)[=-]([^}]+)\}', lambda m: env[m.group(1)] if m.group(1) in env else m.group(2), s)
+    return s
+
+
+if __name__ == '__main__':
+    import sys
+
+    if len(sys.argv) < 2:
+        import doctest
+        doctest.testmod()
+        print('Usage: envsubst.py <string_or_filename>\n')
+    else:
+        arg = sys.argv[1]
+        if os.path.isfile(arg):
+            with open(arg, 'r', encoding='utf-8') as f:
+                print(envsubst(f.read(), os.environ))
+        else:
+            print(envsubst(arg, os.environ))

--- a/src/capi/azext_capi/tests/latest/test_envsubst.py
+++ b/src/capi/azext_capi/tests/latest/test_envsubst.py
@@ -1,0 +1,52 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from collections import namedtuple
+import unittest
+
+from azext_capi.envsubst import envsubst
+
+
+class TestEnvsubst(unittest.TestCase):
+
+    Case = namedtuple('Case', ['input', 'output', 'env'])
+
+    cases = [
+        # Simple value of variable
+        Case('${FOO}', 'bar', {'FOO': 'bar'}),
+        # String length of variable
+        Case('${#FOO}', '3', {'FOO': 'bar'}),
+        # Uppercase first character of variable
+        Case('${FOO^}', 'BaR', {'FOO': 'baR'}),
+        # Uppercase all characters of variable
+        Case('${FOO^^}', 'BAR', {'FOO': 'bar'}),
+        # Lowercase first character of variable
+        Case('${FOO,}', 'bAr', {'FOO': 'BAr'}),
+        # Lowercase all characters of variable
+        Case('${FOO,,}', 'bar', {'FOO': 'BAR'}),
+        # Value of variable from a string position to end
+        Case('${FOO:1}', 'ar', {'FOO': 'bar'}),
+        # Value of variable from a string position with max length
+        Case('${FOO:1:1}', 'a', {'FOO': 'bar'}),
+        # Evaluate default expression if variable is not set
+        Case('${FOO=bar}', 'bar', {}),
+        Case('${FOO=bar}', '', {'FOO': ''}),
+        Case('${FOO-bar}', 'bar', {}),
+        Case('${FOO-bar}', '', {'FOO': ''}),
+        # Evaluate default expression if variable is not set or empty
+        Case('${FOO:-bar}', 'bar', {'FOO': ''}),
+        Case('${FOO:-bar}', 'bar', {}),
+        Case('${FOO:=bar}', 'bar', {'FOO': ''}),
+        Case('${FOO:=bar}', 'bar', {}),
+        # Handle nested expressions
+        Case('${FOO=${BAR^}}', 'Bar', {'BAR': 'bar'}),
+        Case('${FOO:=${BAR}-baz}', 'bar-baz', {'BAR': 'bar'}),
+        Case('${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}',
+             'my-cluster-vnet', {'CLUSTER_NAME': 'my-cluster'}),
+    ]
+
+    def test_envsubst(self):
+        for case in self.cases:
+            self.assertEqual(envsubst(case.input, case.env), case.output)


### PR DESCRIPTION
**Description**

Adds a simple [`envsubst`](https://github.com/drone/envsubst/#supported-functions)-compatible function that could be used for processing external templates.

This may be simpler than trying to install the Go binary that CAPZ uses. I wrote a set of unit tests that use most of the supported functions, and I think this would cover everything we've used in Cluster API templates, but of course the behavior could be different in corner cases. It's also a pretty quick implementation, but it does work.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
