### PR TITLE
Update AZURE_SSH_KEY on jinja templates

### DIFF
--- a/src/capi/azext_capi/templates/KubeadmConfigTemplate.yaml
+++ b/src/capi/azext_capi/templates/KubeadmConfigTemplate.yaml
@@ -10,10 +10,10 @@ spec:
       users:
       - name: capi
         groups: Administrators
-        {% if AZURE_SSH_PUBLIC_KEY %}
+        {%- if AZURE_SSH_PUBLIC_KEY %}
         sshAuthorizedKeys:
         - {{AZURE_SSH_PUBLIC_KEY}}
-        {% endif %}
+        {%- endif %}
       preKubeadmCommands: []
       postKubeadmCommands:
         - nssm set kubelet start SERVICE_AUTO_START


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

This PR aims to fix an exception being raised by failing jinja rendering windows templates validation.
When rendering window templates, we were using `AZURE_SSH_PUBLIC_KEY` which was not passed to jinja arguments and failed validation.  

Updating `AZURE_SSH_PUBLIC_KEY_B64` to `AZURE_SSH_PUBLIC_KEY`

Fixes #91 
**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
