### PR TITLE
Update capi delete to work for self-managed clusters

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -616,6 +616,7 @@ def reset_current_context_and_attributes():
     user = find_attribute_in_context(current_context, "user")
     delete_kubeconfig_attribute(cluster_name, "cluster")
     delete_kubeconfig_attribute(user, "user")
+    delete_kubeconfig_attribute(current_context, "context")
     unset_kubectl_current_context()
 
 
@@ -706,17 +707,61 @@ def get_kubeconfig(capi_name):
     return f"Wrote kubeconfig file to {filename} "
 
 
-def delete_workload_cluster(cmd, capi_name, yes=False):
+def get_azure_cluster(cluster_name, kubeconfig=None):
+    command = ["kubectl", "get", "AzureCluster", cluster_name, "-o", "json"]
+    command += add_kubeconfig_to_command(kubeconfig)
+    try:
+        return run_shell_command(command)
+    except subprocess.CalledProcessError as err:
+        raise InvalidArgumentValueError(f"Could not find {cluster_name}") from err
+
+
+def get_azure_resource_group_from_azure_cluster(cluster_name, kubeconfig=None):
+    output = get_azure_cluster(cluster_name, kubeconfig)
+    output = json.loads(output)
+    return output["spec"]["resourceGroup"]
+
+
+def delete_workload_cluster(cmd, capi_name, resource_group_name=None, yes=False):
     exit_if_no_management_cluster()
     msg = f'Do you want to delete this Kubernetes cluster "{capi_name}"?'
+    command = ["kubectl", "delete", "cluster", capi_name]
+    is_self_managed = is_self_managed_cluster(capi_name)
+    if is_self_managed:
+        if not resource_group_name:
+            resource_group_name = get_azure_resource_group_from_azure_cluster(capi_name)
+        msg = f'Do you want to delete the {capi_name} Kubernetes cluster and {resource_group_name} resource group?'
+        command = ["az", "group", "delete", "-n", resource_group_name, '-y']
     if not yes and not prompt_y_n(msg, default="n"):
         return
-    cmd = ["kubectl", "delete", "cluster", capi_name]
-    try:
-        output = subprocess.check_output(cmd, universal_newlines=True)
-        logger.info("%s returned:\n%s", " ".join(cmd), output)
-    except subprocess.CalledProcessError as err:
-        raise UnclassifiedUserFault("Couldn't delete workload cluster") from err
+    begin_msg = "Deleting workload cluster"
+    end_msg = "✓ Deleted workload cluster"
+    err_msg = "Couldn't delete workload cluster"
+    try_command_with_spinner(cmd, command, begin_msg, end_msg, err_msg)
+    if is_self_managed:
+        reset_current_context_and_attributes()
+
+
+def get_ports_cluster(kubeconfig=None):
+    output = get_kubectl_cluster_info(kubeconfig)
+    match = re.findall(r"(?<=is running at )[^\s]{1,}", output)
+    result = {
+        "control_plane": match[0],
+        "coredns": match[1]
+    }
+    return result
+
+
+def is_self_managed_cluster(cluster_name):
+    management_cluster_ports = get_ports_cluster()
+    workload_cluster_ports = get_ports_cluster(f"{cluster_name}.kubeconfig")
+    return management_cluster_ports == workload_cluster_ports
+
+
+def get_kubectl_cluster_info(kubeconfig=None):
+    command = ["kubectl", "cluster-info"]
+    command += add_kubeconfig_to_command(kubeconfig)
+    return run_shell_command(command)
 
 
 def list_workload_clusters(cmd):  # pylint: disable=unused-argument

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -80,8 +80,9 @@ class CapiScenarioTest(ScenarioTest):
 
             self.assertEqual(mock.call_count, 2)
 
+    @patch('azext_capi.custom.is_self_managed_cluster', return_value=False)
     @patch('azext_capi.custom.exit_if_no_management_cluster')
-    def test_capi_delete(self, mock_def):
+    def test_capi_delete(self, mock_def, mock_is_self_managed):
         # Test (indirectly) that user is prompted for confirmation by default
         with self.assertRaises(NoTTYException):
             self.cmd('capi delete --name testcluster1')


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

This PR aims to added support for deleting a self-managed workload cluster on `az capi delete`
to delete a self-managed cluster, need to use `--resource-group/-g`

This implementation goes the route of directly deleting the resource group of workload cluster.
Instead of creating a temporal management cluster and moving the workload cluster to be deleted into this temporal cluster and issuing delete command to the workload cluster and deleting temporal management cluster.

There is assumption about deleting the resource group of workload cluster.
@mboersma Do you think we should inform or/and ask for confirmation about deleting the entire resource group to the user?

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
