### PR TITLE
add docker as kind's pre-requirement check

### DIFF
--- a/src/capi/azext_capi/helpers/binary.py
+++ b/src/capi/azext_capi/helpers/binary.py
@@ -11,7 +11,7 @@ import stat
 
 from azure.cli.core.azclierror import FileOperationError
 from azure.cli.core.azclierror import InvalidArgumentValueError
-from azure.cli.core.azclierror import ValidationError
+from azure.cli.core.azclierror import ValidationError, UnclassifiedUserFault
 from knack.prompting import prompt_y_n
 from six.moves.urllib.request import urlopen  # pylint: disable=import-error
 
@@ -43,11 +43,19 @@ def check_clusterctl(cmd, install=False):
 
 
 def check_kind(cmd, install=False):
+    check_prereq_docker()
     check_binary(cmd, "kind", install_kind, install)
 
 
 def check_kubectl(cmd, install=False):
     check_binary(cmd, "kubectl", install_kubectl, install)
+
+
+def check_prereq_docker():
+    if which("docker"):
+        return True
+    error_msg = "Docker is required to use kind. To install see: https://docs.docker.com/get-docker/"
+    raise UnclassifiedUserFault(error_msg)
 
 
 def check_binary(cmd, binary_name, install_binary_method, install=False):


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

This PR aims to add extra validation to check for docker when installing kind.  To prevent failures when using kind if pre-requirements were not found.

Fixes #101 

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
