### PR TITLE
Improve tab-separated output for capi show and list

### DIFF
--- a/src/capi/azext_capi/_format.py
+++ b/src/capi/azext_capi/_format.py
@@ -4,8 +4,15 @@
 # --------------------------------------------------------------------------------------------
 
 """
-This module contains JMESPath queries to format output for the az capi extension.
+This module contains functions and JMESPath queries to format output for the az capi extension.
+
+The knack CLI framework does not expect the JSON structures returned by `kubectl`. These
+transformations expose useful fields for the table and tab-separated output formats.
 """
+
+import json
+
+import jmespath
 
 
 CLUSTER_TABLE_FORMAT = """\
@@ -17,11 +24,14 @@ CLUSTER_TABLE_FORMAT = """\
 }
 """
 
-CLUSTERS_LIST_TABLE_FORMAT = """\
-items[].{
-    name: metadata.name,
-    phase: status.phase,
-    created: metadata.creationTimestamp,
-    namespace: metadata.namespace
-}
-"""
+CLUSTERS_LIST_TABLE_FORMAT = f"items[].{CLUSTER_TABLE_FORMAT}"
+
+
+def output_for_tsv(s):
+    """Return JSON data to output a cluster in tab-separated format."""
+    return jmespath.search(CLUSTER_TABLE_FORMAT, json.loads(s))
+
+
+def output_list_for_tsv(s):
+    """Return JSON data to output a list of clusters in tab-separated format."""
+    return jmespath.search(CLUSTERS_LIST_TABLE_FORMAT, json.loads(s))

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -60,7 +60,10 @@ class CapiScenarioTest(ScenarioTest):
             count = len(self.cmd("capi list --output json").get_output_in_json())
             self.assertEqual(count, 4)  # "apiVersion", "items", "kind", and "metadata".
 
-            self.assertEqual(mock.call_count, 2)
+            tsv = self.cmd("capi list --output tsv").output
+            self.assertEqual(tsv, '2022-05-27T20:53:08Z\tdefault-4377\tdefault\tProvisioned\n2022-05-27T20:58:06Z\ttestcluster1\tdefault\tProvisioned\n')
+
+            self.assertEqual(mock.call_count, 3)
 
     @patch('azext_capi.custom.exit_if_no_management_cluster')
     def test_capi_show(self, mock_def):
@@ -78,7 +81,10 @@ class CapiScenarioTest(ScenarioTest):
             count = len(self.cmd("capi show --name testcluster1 --output json").get_output_in_json())
             self.assertEqual(count, 5)  # "apiVersion", "kind", "metadata", "spec", and "status"
 
-            self.assertEqual(mock.call_count, 2)
+            tsv = self.cmd("capi show --name testcluster1 --output tsv").output
+            self.assertEqual(tsv, '2022-05-27T20:58:06Z\ttestcluster1\tdefault\tProvisioned\n')
+
+            self.assertEqual(mock.call_count, 3)
 
     @patch('azext_capi.custom.is_self_managed_cluster', return_value=False)
     @patch('azext_capi.custom.exit_if_no_management_cluster')


### PR DESCRIPTION
**Description**

Fixes #26

Before:

```shell
% az capi list -o tsv
v1	2	List
% az capi show -n testcluster1 -o tsv
cluster.x-k8s.io/v1beta1	Cluster
```

After:

```shell
% az capi list -o tsv                
2022-05-27T20:53:08Z	default-4377	default	Provisioned
2022-05-27T20:58:06Z	testcluster1	default	Provisioned
% az capi show -n testcluster1 -o tsv
2022-05-27T20:58:06Z	testcluster1	default	Provisioned
```

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
