### PR TITLE
Fixed writing kubeconfig file

### DIFF
--- a/src/capi/azext_capi/helpers/kubectl.py
+++ b/src/capi/azext_capi/helpers/kubectl.py
@@ -17,8 +17,9 @@ from azure.cli.core.azclierror import ResourceNotFoundError
 from azure.cli.core.azclierror import InvalidArgumentValueError
 
 from .run_command import run_shell_command
-from .logger import logger
+from .os import write_to_file
 from .generic import match_output
+from .logger import logger
 from .constants import KUBECONFIG
 
 
@@ -129,12 +130,11 @@ def get_kubeconfig(capi_name):
     """Writes kubeconfig of specified cluster"""
     cmd = ["clusterctl", "get", "kubeconfig", capi_name]
     try:
-        output = run_shell_command(cmd)
+        output = run_shell_command(cmd, combine_std=False)
     except subprocess.CalledProcessError as err:
         raise UnclassifiedUserFault("Couldn't get kubeconfig") from err
     filename = capi_name + ".kubeconfig"
-    with open(filename, "w", encoding="utf-8") as kubeconfig_file:
-        kubeconfig_file.write(output)
+    write_to_file(filename, output)
     return f"Wrote kubeconfig file to {filename} "
 
 

--- a/src/capi/azext_capi/helpers/run_command.py
+++ b/src/capi/azext_capi/helpers/run_command.py
@@ -13,9 +13,11 @@ from .spinner import Spinner
 from .logger import logger, is_verbose
 
 
-def run_shell_command(command):
+def run_shell_command(command, combine_std=True):
     # if --verbose, don't capture stderr
-    stderr = None if is_verbose() else subprocess.STDOUT
+    stderr = None
+    if combine_std:
+        stderr = None if is_verbose() else subprocess.STDOUT
     output = subprocess.check_output(command, universal_newlines=True, stderr=stderr)
     logger.info("%s returned:\n%s", " ".join(command), output)
     return output


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

This PR aims to fix writing kubeconfig file with warning message on it

To get the kubeconfig of a workload cluster we are running ` clusterctl get kubeconfig <cluster-name>` through `run_shell_command` this method combines `STDERR & STDOUT` by default.

The approach to this fix is allow option to no combine `STDERR & STDOUT`

Fixes #137
**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
