### PR TITLE
Update `capi management delete` behavior

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -209,30 +209,44 @@ Where do you want to create a management cluster?
     return True
 
 
+def find_resource_group_name_of_aks_cluster(cluster_name):
+    jmespath_query = "[].{name:name, group:resourceGroup}"
+    command = ["az", "aks", "list", "--query", jmespath_query]
+    result = run_shell_command(command)
+    result = json.loads(result)
+    result = [item for item in result if item['name'] == cluster_name]
+    if result:
+        return result[0]["group"]
+    return None
+
+
 def delete_management_cluster(cmd, yes=False):  # pylint: disable=unused-argument
     exit_if_no_management_cluster()
-    msg = 'Do you want to delete Cluster API components from the current cluster?'
+    cluster_name = kubectl_helpers.find_cluster_in_current_context()
+
+    msg = f"Do you want to delete {cluster_name} cluster?"
+
+    cluster_resource_group = None
+    is_kind_cluster = has_kind_prefix(cluster_name)
+    if not is_kind_cluster:
+        cluster_resource_group = find_resource_group_name_of_aks_cluster(cluster_name)
+        if not cluster_resource_group:
+            prompt = f"Please enter resource group name of {cluster_name} AKS cluster: "
+            cluster_resource_group = get_user_prompt_or_default(prompt, cluster_name, skip_prompt=yes)
+            msg = f"Do you want to delete {cluster_name} cluster and resource group {cluster_resource_group}?"
+
+    pre_workload_warning = f"""\
+Please make sure to delete all workload clusters managed by {cluster_name} management cluster before proceeding \
+to prevent any orphan workload cluster
+"""
+    msg = pre_workload_warning + msg
     if not yes and not prompt_y_n(msg, default="n"):
         return
 
-    command = ["clusterctl", "delete", "--all",
-               "--include-crd", "--include-namespace"]
-    try:
-        run_shell_command(command)
-    except subprocess.CalledProcessError as err:
-        raise UnclassifiedUserFault("Couldn't delete components from management cluster") from err
-    namespaces = [
-        "capi-kubeadm-bootstrap-system",
-        "capi-kubeadm-control-plane-system",
-        "capi-system",
-        "capz-system",
-        "cert-manager",
-    ]
-    command = ["kubectl", "delete", "namespace", "--ignore-not-found"] + namespaces
-    try:
-        run_shell_command(command)
-    except subprocess.CalledProcessError as err:
-        raise UnclassifiedUserFault("Couldn't delete namespaces from management cluster") from err
+    if is_kind_cluster:
+        delete_kind_cluster_from_current_context(cmd)
+    else:
+        delete_aks_cluster(cmd, cluster_name, cluster_resource_group)
 
 
 def move_management_cluster(cmd):

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -101,20 +101,20 @@ class CapiScenarioTest(ScenarioTest):
             self.assertTrue(mock.called)
             self.assertEqual(mock.call_args[0][0], ["kubectl", "delete", "cluster", "testcluster1"])
 
+    @patch('azext_capi.custom.delete_aks_cluster')
+    @patch('azext_capi.custom.delete_kind_cluster_from_current_context')
+    @patch('azext_capi.custom.has_kind_prefix')
+    @patch('azext_capi.custom.kubectl_helpers.find_cluster_in_current_context')
     @patch('azext_capi.custom.exit_if_no_management_cluster')
-    def test_capi_management_delete(self, mock_def):
+    def test_capi_management_delete(self, mock_def, find_cluster_mock, kind_pref_mock, delete_kind_mock, delete_aks_mock):
         # Test (indirectly) that user is prompted for confirmation by default
         with self.assertRaises(NoTTYException):
             self.cmd('capi management delete')
 
         # Test that --yes skips confirmation and the management cluster components are deleted
-        with patch('subprocess.check_output') as mock:
             self.cmd("capi management delete -y", checks=[
                 self.is_empty(),
             ])
-            self.assertEqual(mock.call_count, 2)
-            self.assertEqual(mock.call_args_list[0][0][0], ["clusterctl", "delete", "--all", "--include-crd", "--include-namespace"])
-            self.assertEqual(mock.call_args_list[1][0][0][:4], ["kubectl", "delete", "namespace", "--ignore-not-found"])
 
     @patch('azext_capi.custom.exit_if_no_management_cluster')
     def test_capi_management_update(self, mock_def):


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

This PR aims to update the current behavior of `az capi management delete` to a more expected behavior of deleting the management cluster on its entirety. Instead of just removing CAPI components out of the cluster

See #133
**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
