### PR TITLE
Add random cluster name generator

### DIFF
--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -81,6 +81,9 @@ parameters:
     type: integer
   - name: --node-machine-type
     type: string
+  - name: --name -n
+    type: string
+    long-summary: If not specified, a random name will be generated.
   - name: --output-path -p
     type: string
     short-summary: Where to save helper commands when they are downloaded

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -414,9 +414,9 @@ def check_resource_group(cmd, resource_group_name, default_resource_group_name, 
 
 
 # pylint: disable=inconsistent-return-statements
-def create_workload_cluster(  # pylint: disable=unused-argument,too-many-arguments,too-many-locals,too-many-statements
+def create_workload_cluster(  # pylint: disable=too-many-arguments,too-many-locals,too-many-statements
         cmd,
-        capi_name,
+        capi_name=None,
         resource_group_name=None,
         location=None,
         control_plane_machine_type=os.environ.get("AZURE_CONTROL_PLANE_MACHINE_TYPE", "Standard_D2s_v3"),
@@ -436,6 +436,11 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         user_provided_template=None,
         bootstrap_commands=None,
         yes=False):
+
+    if not capi_name:
+        from .helpers.names import generate_cluster_name
+        capi_name = generate_cluster_name()
+        logger.warning('Using generated cluster name "%s"', capi_name)
 
     if user_provided_template:
         mutual_exclusive_args = [

--- a/src/capi/azext_capi/helpers/names.py
+++ b/src/capi/azext_capi/helpers/names.py
@@ -1,0 +1,83 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+import random
+
+
+def generate_cluster_name(seed=None):
+    """
+    Return a randomly-generated memorable name, such as \"earthy-mainsail.\"
+
+    >>> generate_cluster_name(69)
+    'vulcan-bagpiper'
+    >>> generate_cluster_name(78)
+    'gaslit-doghouse'
+    >>> generate_cluster_name(929)
+    'gentle-teamwork'
+    """
+    adjectives = [
+        'ablest', 'absurd', 'actual', 'aerial', 'allied', 'artful', 'atomic', 'august',
+        'bamboo', 'benign', 'blonde', 'blurry', 'bolder', 'breezy', 'bubbly', 'burley',
+        'calmer', 'candid', 'casual', 'cheery', 'classy', 'clever', 'convex', 'cubist',
+        'dainty', 'dapper', 'decent', 'deluxe', 'docile', 'dogged', 'drafty', 'dreamy',
+        'earthy', 'easier', 'echoed', 'edible', 'elfish', 'excess', 'exotic', 'expert',
+        'fabled', 'famous', 'feline', 'finest', 'flaxen', 'folksy', 'frisky', 'frozen',
+        'gaslit', 'gentle', 'gifted', 'ginger', 'global', 'golden', 'grassy', 'guided',
+        'haptic', 'hearty', 'hidden', 'hipper', 'honest', 'humble', 'hungry', 'hushed',
+        'iambic', 'iciest', 'iconic', 'indoor', 'inward', 'ironic', 'island', 'italic',
+        'jagged', 'jangly', 'jaunty', 'jicama', 'jiggly', 'jovial', 'joyful', 'junior',
+        'kabuki', 'karmic', 'keener', 'kiddie', 'kindly', 'kingly', 'klutzy', 'knotty',
+        'lambda', 'latest', 'leader', 'linear', 'lively', 'lonely', 'loving', 'luxury',
+        'madcap', 'madras', 'marble', 'mellow', 'metric', 'modest', 'molten', 'mystic',
+        'native', 'nearby', 'nested', 'newish', 'nickel', 'nimbus', 'nonfat', 'normal',
+        'oblong', 'oddest', 'offset', 'oldest', 'onside', 'orange', 'outlaw', 'owlish',
+        'padded', 'pastry', 'peachy', 'pepper', 'player', 'preset', 'proper', 'pulsar',
+        'quacky', 'quaint', 'quartz', 'queens', 'queued', 'quinoa', 'quirky', 'quoted',
+        'racing', 'rental', 'ribbed', 'rising', 'rococo', 'rubber', 'rugged', 'rustic',
+        'sanest', 'scenic', 'seeing', 'shadow', 'skiing', 'stable', 'steely', 'syrupy',
+        'taller', 'tender', 'tested', 'timely', 'trendy', 'triple', 'truthy', 'twenty',
+        'ultima', 'unbent', 'unisex', 'united', 'upbeat', 'uphill', 'usable', 'utmost',
+        'vacuum', 'valued', 'vanity', 'velcro', 'velvet', 'verbal', 'violet', 'vulcan',
+        'walkup', 'webbed', 'wicker', 'wiggly', 'wilder', 'wonder', 'wooden', 'woodsy',
+        'yearly', 'yeasty', 'yellow', 'yeoman', 'yogurt', 'yonder', 'youthy', 'yuppie',
+        'zaftig', 'zanier', 'zephyr', 'zeroed', 'zigzag', 'zipped', 'zircon', 'zydeco',
+    ]
+    nouns = [
+        'addendum', 'anaconda', 'airfield', 'aqualung', 'armchair', 'asteroid', 'autoharp',
+        'babushka', 'backbone', 'bagpiper', 'barbecue', 'bookworm', 'bullfrog', 'buttress',
+        'caffeine', 'checkers', 'chinbone', 'countess', 'crawfish', 'cucumber', 'cutpurse',
+        'daffodil', 'darkroom', 'deadbolt', 'doghouse', 'dragster', 'drumroll', 'duckling',
+        'earrings', 'earthman', 'eggplant', 'electron', 'elephant', 'espresso', 'eyetooth',
+        'falconer', 'farmland', 'ferryman', 'fireball', 'fishbone', 'footwear', 'frosting',
+        'gadabout', 'gasworks', 'gatepost', 'gemstone', 'gladness', 'goldfish', 'greenery',
+        'hacienda', 'handbill', 'hardtack', 'hawthorn', 'headwind', 'henhouse', 'huntress',
+        'icehouse', 'idealist', 'inchworm', 'instinct', 'inventor', 'insignia', 'ironwood',
+        'jailbird', 'jamboree', 'jerrycan', 'jetliner', 'jokester', 'joyrider', 'jumpsuit',
+        'kangaroo', 'keepsake', 'kerchief', 'keypunch', 'kingfish', 'knapsack', 'knothole',
+        'ladybird', 'lakeside', 'lambskin', 'landmass', 'larkspur', 'lollipop', 'lungfish',
+        'macaroni', 'mackinaw', 'magician', 'mainsail', 'milepost', 'mongoose', 'moonrise',
+        'nailhead', 'nautilus', 'neckwear', 'newsreel', 'nonesuch', 'novelist', 'nuthatch',
+        'occupant', 'odometer', 'offering', 'offshoot', 'original', 'organism', 'overalls',
+        'pachinko', 'painting', 'pamphlet', 'paneling', 'pendulum', 'playroom', 'ponytail',
+        'quacking', 'quadrant', 'quantity', 'queendom', 'question', 'quilting', 'quotient',
+        'rabbitry', 'radiator', 'renegade', 'ricochet', 'riverbed', 'rosewood', 'rucksack',
+        'sailfish', 'sandwich', 'sculptor', 'seashore', 'seedcake', 'skylight', 'stickpin',
+        'tabletop', 'tailbone', 'teamwork', 'teaspoon', 'tinkerer', 'traverse', 'turbojet',
+        'umbrella', 'underdog', 'undertow', 'unicycle', 'universe', 'uptowner', 'utensils',
+        'vacation', 'vagabond', 'valkyrie', 'variable', 'villager', 'vineyard', 'vocalist',
+        'waggoner', 'waxworks', 'waterbed', 'wayfarer', 'whitecap', 'windmill', 'woodshed',
+        'yachting', 'yardbird', 'yardwork', 'yearbook', 'yearling', 'yeomanry', 'yodeling',
+        'zaniness', 'zeppelin', 'ziggurat', 'zillions', 'zirconia', 'zoologer', 'zucchini',
+    ]
+    random.seed(seed)
+    return f"{random.choice(adjectives)}-{random.choice(nouns)}"
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()
+
+    print(generate_cluster_name())

--- a/src/capi/azext_capi/tests/latest/test_helpers.py
+++ b/src/capi/azext_capi/tests/latest/test_helpers.py
@@ -20,6 +20,7 @@ import azext_capi.helpers.generic as generic
 from azext_capi.custom import create_resource_group, create_new_management_cluster, management_cluster_components_missing_matching_expressions, get_default_bootstrap_commands, parse_bootstrap_commands_from_file
 from azext_capi.helpers.prompt import get_user_prompt_or_default
 from azext_capi.helpers.kubectl import check_kubectl_namespace, find_attribute_in_context, find_kubectl_current_context, find_default_cluster, add_kubeconfig_to_command
+from azext_capi.helpers.names import generate_cluster_name
 from azext_capi.helpers.run_command import try_command_with_spinner, run_shell_command
 
 
@@ -519,3 +520,22 @@ class IsClusterctlCompatible(unittest.TestCase):
         self.os_path_isfile_mock.return_value = True
         self.assertTrue(generic.is_clusterctl_compatible("testfile.yaml"))
         self.assertTrue(generic.is_clusterctl_compatible("./testfile.yaml"))
+
+
+class TestGenerateClusterName(unittest.TestCase):
+
+    def test_generate_cluster_name(self):
+        cases = {
+            4990: "rococo-aqualung",
+            4991: "guided-vocalist",
+            4992: "hungry-inventor",
+            4993: "timely-renegade",
+            4994: "clever-earthman",
+            4995: "vulcan-instinct",
+            4996: "iconic-tabletop",
+            4997: "zircon-goldfish",
+            4998: "ultima-electron",
+            4999: "steely-footwear",
+        }
+        for seed, name in cases.items():
+            self.assertEqual(generate_cluster_name(seed), name)


### PR DESCRIPTION
**Description**

Changes the behavior of `az capi create` so if no `--name` argument is provided, it generates a random one:

```shell
% az capi create -l westus3
Command group 'capi' is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus
Using generated cluster name "lively-lakeside"
...
```

Fixes #119

cc: @nawazkh

This code was adapted from deis-controller code I wrote ten years ago. I believe this reuse is legitimate since:
- the origin and target codebases are both MIT-licensed
- all code and IP of Deis was transferred to Microsoft upon acquisition

**History Notes**

az capi create: add random cluster name generator

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
