### PR TITLE
Add `AZURE_LOCATION` as default `--location` in `capi create`

### DIFF
--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -69,9 +69,9 @@ parameters:
   - name: --location -l
     type: string
     long-summary: |
-        If not specified, the location of the --resource-group will be used.
-        if --resource-group is not specified or does not yet exist, AZURE_LOCATION will be used.
-        Required if --resource-group or AZURE_LOCATION are not set.
+        If not specified, default configured location or AZURE_LOCATION will be used (in this order).
+        If --resource-group is specified and already exists, the location has to match.
+        Required if default location is not configured or AZURE_LOCATION is not set.
   - name: --machinepool -m
     type: bool
     short-summary: Use experimental MachinePools instead of MachineDeployments

--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -70,7 +70,8 @@ parameters:
     type: string
     long-summary: |
         If not specified, the location of the --resource-group will be used.
-        Required if --resource-group is not specified or does not yet exist
+        if --resource-group is not specified or does not yet exist, AZURE_LOCATION will be used.
+        Required if --resource-group or AZURE_LOCATION are not set.
   - name: --machinepool -m
     type: bool
     short-summary: Use experimental MachinePools instead of MachineDeployments

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -394,8 +394,6 @@ def check_resource_group(cmd, resource_group_name, default_resource_group_name, 
     from ._client_factory import cf_resource_groups  # pylint: disable=import-outside-toplevel
 
     rg_client = cf_resource_groups(cmd.cli_ctx)
-    if not location:
-        location = os.environ.get("AZURE_LOCATION", None)
     if not resource_group_name:
         resource_group_name = default_resource_group_name
     try:
@@ -438,6 +436,9 @@ def create_workload_cluster(  # pylint: disable=unused-argument,too-many-argumen
         user_provided_template=None,
         bootstrap_commands=None,
         yes=False):
+
+    if location is None:
+        location = os.environ.get("AZURE_LOCATION", None)
 
     if user_provided_template:
         mutual_exclusive_args = [

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -394,6 +394,8 @@ def check_resource_group(cmd, resource_group_name, default_resource_group_name, 
     from ._client_factory import cf_resource_groups  # pylint: disable=import-outside-toplevel
 
     rg_client = cf_resource_groups(cmd.cli_ctx)
+    if not location:
+        location = os.environ.get("AZURE_LOCATION", None)
     if not resource_group_name:
         resource_group_name = default_resource_group_name
     try:
@@ -407,10 +409,8 @@ def check_resource_group(cmd, resource_group_name, default_resource_group_name, 
         if 'could not be found' not in err.message:
             raise
         if not location:
-            location = os.environ.get("AZURE_LOCATION", None)
-            if not location:
-                msg = "--location is required to create the resource group {}."
-                raise RequiredArgumentMissingError(msg.format(resource_group_name)) from err
+            msg = "--location is required to create the resource group {}."
+            raise RequiredArgumentMissingError(msg.format(resource_group_name)) from err
         logger.warning("Could not find an Azure resource group, CAPZ will create one for you")
     return resource_group_name
 

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -407,8 +407,10 @@ def check_resource_group(cmd, resource_group_name, default_resource_group_name, 
         if 'could not be found' not in err.message:
             raise
         if not location:
-            msg = "--location is required to create the resource group {}."
-            raise RequiredArgumentMissingError(msg.format(resource_group_name)) from err
+            location = os.environ.get("AZURE_LOCATION", None)
+            if not location:
+                msg = "--location is required to create the resource group {}."
+                raise RequiredArgumentMissingError(msg.format(resource_group_name)) from err
         logger.warning("Could not find an Azure resource group, CAPZ will create one for you")
     return resource_group_name
 

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import os
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch, ANY
 
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.core.azclierror import InvalidArgumentValueError
@@ -41,11 +41,11 @@ class CapiScenarioTest(ScenarioTest):
             with self.assertRaises(RequiredArgumentMissingError):
                 self.cmd('capi create -n myClusterName -g myCluster')
         # New RG, no --location, AZURE_LOCATION set
-        with patch('azext_capi._client_factory.cf_resource_groups') as cf_resource_groups:
-            with patch.dict('os.environ', {"AZURE_LOCATION": "westus3"}):
-                cf_resource_groups.return_value = mock_client
+        with patch.dict('os.environ', {"AZURE_LOCATION": "westus3"}):
+            with patch('azext_capi.custom.check_resource_group') as mock_check_rg:
                 with self.assertRaises(NoTTYException):
                     self.cmd('capi create -n myClusterName -g myCluster')
+                mock_check_rg.assert_called_with(ANY, ANY, ANY, "westus3")
         # New RG, --location specified but no --resource-group name
         with patch('azext_capi._client_factory.cf_resource_groups') as cf_resource_groups:
             cf_resource_groups.return_value = mock_client


### PR DESCRIPTION
Hi, this closes #120.

When --location isn't specified, it's now determined by:
1. config file [defaults]
2. resource-group
3. AZURE_LOCATION
4. still None -> raise RequiredArgumentMissingError

Did I miss anything?

Edit: actually when i think about it, maybe it makes more sense to have config file [defaults] and AZURE_LOCATION both either before resource-group or both after..