### PR TITLE
Validate --kubernetes arg and ensure it starts with "v"

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -16,6 +16,7 @@ import re
 import yaml
 
 import azext_capi.helpers.kubectl as kubectl_helpers
+import semver
 
 from azure.cli.core import get_default_cli
 from azure.cli.core.api import get_config_dir
@@ -458,6 +459,13 @@ def create_workload_cluster(  # pylint: disable=too-many-arguments,too-many-loca
         from .helpers.names import generate_cluster_name
         capi_name = generate_cluster_name()
         logger.warning('Using generated cluster name "%s"', capi_name)
+
+    if not kubernetes_version.startswith('v'):
+        kubernetes_version = f'v{kubernetes_version}'
+    try:
+        semver.parse(kubernetes_version[1:])
+    except ValueError as err:
+        raise InvalidArgumentValueError(f'Invalid Kubernetes version: "{kubernetes_version}"') from err
 
     if user_provided_template:
         mutual_exclusive_args = [


### PR DESCRIPTION
**Description**

Prepends a "v" to the `--kubernetes` argument so it always ends up in templates as expected: "v1.24.1" for example. Also validates that the argument is a valid semantic version using the `semver` library which was already in use by `az`.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
