### PR TITLE
Allow passing tags through on creation of management cluster in CAPZ

### DIFF
--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -41,6 +41,9 @@ def load_arguments(self, _):
         ctx.argument('management_cluster_resource_group_name',
                      options_list=['--management-cluster-resource-group-name', '-mg'],
                      help="Resource group name of management cluster")
+        ctx.argument('tags',
+                     options_list=['--tags', '-t'],
+                     help="Tags applied to the AKS management cluster and resource group if created in Azure")
 
     with self.argument_context('capi install') as ctx:
         ctx.argument('all_tools', capi_name_type, options_list=['--all', '-a'])


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**
This adds support for passing custom tags through to the AKS management cluster and resource groups. 

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
