### PR TITLE
Add nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,60 @@
+name: az-capi-nightly
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '45 0 * * *' # Every day at 00:45 UTC 
+  workflow_dispatch:
+
+env:
+  IMAGE: Azure/azure-capi-cli-extension
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+
+    - name: Install dependencies
+      run: |
+        python -m venv env
+        source env/bin/activate
+
+        python -m pip install -U pip
+        python -m pip install -r requirements.txt
+        azdev setup --repo . --ext capi
+    
+    - name: Build extension
+      run: |
+        source env/bin/activate
+
+        # set to vnext for versioning
+        sed -i "s/VERSION = '.*'/VERSION = '0.0.vnext'/g" src/capi/setup.py
+        azdev extension build capi
+
+        WHEEL=$(find ./dist -name "*.whl" -printf "%f")
+        echo "WHEEL=$WHEEL" >> $GITHUB_ENV
+
+    # sometimes eine/tip@master fails to upload release artifacts and this leaves
+    # a stale tmp file on the release which causes future runs of this workflow to fail.
+    - name: delete tmp.* release artifacts
+      uses: mknejp/delete-release-assets@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: az-capi-nightly
+        fail-if-no-assets: false # do not fail if does not exist
+        assets: tmp.${{ env.WHEEL }}
+
+    - uses: pyTooling/Actions/releaser@r0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: az-capi-nightly
+        files: |
+          dist/${{ env.WHEEL }}

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # Pycharm project configuration
 .idea
+
+# user env variables
+.user.env


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

Allows for using changes from the main branch in testing.

I got this working on my fork: https://github.com/jsturtevant/azure-capi-cli-extension/releases/tag/az-capi-nightly

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
