### PR TITLE
Add configurable install path for binaries

### DIFF
--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -129,6 +129,8 @@ short-summary: Install all needed tools.
 parameters:
   - name: --all -a
     type: bool
+  - name: --install-path -ip
+    type: string
 """
 
 helps['capi show'] = """

--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -47,6 +47,7 @@ def load_arguments(self, _):
 
     with self.argument_context('capi install') as ctx:
         ctx.argument('all_tools', capi_name_type, options_list=['--all', '-a'])
+        ctx.argument('install_path', options_list=['--install-path', '-ip'])
 
 
 def get_virtualenv():

--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -46,8 +46,8 @@ def load_arguments(self, _):
                      help="Tags applied to the AKS management cluster and resource group if created in Azure")
 
     with self.argument_context('capi install') as ctx:
-        ctx.argument('all_tools', capi_name_type, options_list=['--all', '-a'])
-        ctx.argument('install_path', 
+        ctx.argument('all_tools', options_list=['--all', '-a'], help="Install all tools")
+        ctx.argument('install_path',
                      options_list=['--install-path', '-ip'],
                      help="Path to install the required tools to")
 

--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -47,7 +47,9 @@ def load_arguments(self, _):
 
     with self.argument_context('capi install') as ctx:
         ctx.argument('all_tools', capi_name_type, options_list=['--all', '-a'])
-        ctx.argument('install_path', options_list=['--install-path', '-ip'])
+        ctx.argument('install_path', 
+                     options_list=['--install-path', '-ip'],
+                     help="Path to install the required tools to")
 
 
 def get_virtualenv():

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -782,7 +782,7 @@ def install_tools(cmd, all_tools=False, install_path=None):
         logger.info('Checking if required tools are installed')
         check_tools(cmd, install=True, install_path=install_path)
     else:
-        logger.info('Installing individual tools is not currently supported')
+        logger.warning('Installing individual tools is not currently supported')
 
 
 def check_tools(cmd, install=False, install_path=None):

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -777,17 +777,17 @@ def update_workload_cluster(cmd, capi_name):
     raise NotImplementedError
 
 
-def install_tools(cmd, all_tools=False):
+def install_tools(cmd, all_tools=False, install_path=None):
     if all_tools:
         logger.info('Checking if required tools are installed')
-        check_tools(cmd, True)
+        check_tools(cmd, install=True, install_path=install_path)
     else:
         logger.info('Installing individual tools is not currently supported')
 
 
-def check_tools(cmd, install=False):
-    check_kubectl(cmd, install)
-    check_clusterctl(cmd, install)
+def check_tools(cmd, install=False, install_path=None):
+    check_kubectl(cmd, install, install_path=install_path)
+    check_clusterctl(cmd, install, install_path=install_path)
 
 
 def check_prereqs(cmd, install=False):

--- a/src/capi/azext_capi/helpers/binary.py
+++ b/src/capi/azext_capi/helpers/binary.py
@@ -60,7 +60,7 @@ def check_prereq_docker():
 
 
 def check_binary(cmd, binary_name, install_binary_method, install=False, install_path=None):
-    if not which(binary_name):
+    if not which(binary_name) or install_path is not None:
         logger.info("%s was not found.", binary_name)
         if install or prompt_y_n(f"Download and install {binary_name}?", default="n"):
             with Spinner(cmd, f"Downloading {binary_name}", f"✓ Downloaded {binary_name}"):

--- a/src/capi/azext_capi/helpers/binary.py
+++ b/src/capi/azext_capi/helpers/binary.py
@@ -5,6 +5,7 @@
 
 # pylint: disable=missing-docstring
 
+from gettext import install
 import os
 import platform
 import stat
@@ -38,17 +39,17 @@ def which(binary):
     return None
 
 
-def check_clusterctl(cmd, install=False):
-    check_binary(cmd, "clusterctl", install_clusterctl, install)
+def check_clusterctl(cmd, install=False, install_path=None):
+    check_binary(cmd, "clusterctl", install_clusterctl, install, install_path=install_path)
 
 
-def check_kind(cmd, install=False):
+def check_kind(cmd, install=False, install_path=None):
     check_prereq_docker()
-    check_binary(cmd, "kind", install_kind, install)
+    check_binary(cmd, "kind", install_kind, install, install_path=install_path)
 
 
-def check_kubectl(cmd, install=False):
-    check_binary(cmd, "kubectl", install_kubectl, install)
+def check_kubectl(cmd, install=False, install_path=None):
+    check_binary(cmd, "kubectl", install_kubectl, install, install_path=install_path)
 
 
 def check_prereq_docker():
@@ -58,12 +59,12 @@ def check_prereq_docker():
     raise UnclassifiedUserFault(error_msg)
 
 
-def check_binary(cmd, binary_name, install_binary_method, install=False):
+def check_binary(cmd, binary_name, install_binary_method, install=False, install_path=None):
     if not which(binary_name):
         logger.info("%s was not found.", binary_name)
         if install or prompt_y_n(f"Download and install {binary_name}?", default="n"):
             with Spinner(cmd, f"Downloading {binary_name}", f"✓ Downloaded {binary_name}"):
-                install_binary_method(cmd)
+                install_binary_method(cmd, install_location=install_path)
 
 
 def install_clusterctl(_cmd, client_version="latest", install_location=None, source_url=None):
@@ -87,7 +88,9 @@ def install_clusterctl(_cmd, client_version="latest", install_location=None, sou
         raise ValidationError(f'The clusterctl binary is not available for "{system}"')
 
     # ensure installation directory exists
-    if install_location is None:
+    if install_location:
+        install_location = f'{install_location}/clusterctl'
+    else:
         install_location = _get_default_install_location("clusterctl")
     install_dir, cli = os.path.dirname(install_location), os.path.basename(
         install_location
@@ -107,7 +110,9 @@ def install_kind(_cmd, client_version="v0.10.0", install_location=None, source_u
         source_url = "https://kind.sigs.k8s.io/dl/{}/kind-{}-amd64"
 
     # ensure installation directory exists
-    if install_location is None:
+    if install_location:
+        install_location = f'{install_location}/kind'
+    else:
         install_location = _get_default_install_location("kind")
     install_dir, cli = os.path.dirname(install_location), os.path.basename(
         install_location
@@ -151,7 +156,9 @@ def install_kubectl(cmd, client_version="latest", install_location=None, source_
     base_url = source_url + "/{}/bin/{}/amd64/{}"
 
     # ensure installation directory exists
-    if install_location is None:
+    if install_location:
+        install_location = f'{install_location}/kubectl'
+    else:
         install_location = _get_default_install_location("kubectl")
     install_dir, cli = os.path.dirname(install_location), os.path.basename(
         install_location


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**
In some environments, users won't have access to /usr/local/bin. This PR adds the `--install-path -ip` flag to `az capi install` so users can specify a specific installation path for binaries.

Fixes #16 

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->
az capi install: Add --install-path flag
---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
