### PR TITLE
Don't recreate the resource group for AKS

### DIFF
--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -114,6 +114,12 @@ class CapiScenarioTest(ScenarioTest):
             self.assertTrue(mock.called)
             self.assertEqual(mock.call_args[0][0], ["kubectl", "delete", "cluster", "testcluster1"])
 
+    @patch('azext_capi.custom.check_prereqs')
+    def test_capi_management_create(self, mock_def):
+        # Test (indirectly) that user is prompted for confirmation by default
+        with self.assertRaises(NoTTYException):
+            self.cmd('capi management create')
+
     @patch('azext_capi.custom.delete_aks_cluster')
     @patch('azext_capi.custom.delete_kind_cluster_from_current_context')
     @patch('azext_capi.custom.has_kind_prefix')
@@ -125,9 +131,9 @@ class CapiScenarioTest(ScenarioTest):
             self.cmd('capi management delete')
 
         # Test that --yes skips confirmation and the management cluster components are deleted
-            self.cmd("capi management delete -y", checks=[
-                self.is_empty(),
-            ])
+        self.cmd("capi management delete -y", checks=[
+            self.is_empty(),
+        ])
 
     @patch('azext_capi.custom.exit_if_no_management_cluster')
     def test_capi_management_update(self, mock_def):


### PR DESCRIPTION
**Description**

When creating an AKS management cluster, we would `az group create` over the top of an existing RG, which deletes its tags. This changes so we check first and skip that if the RG exists.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
