### PR TITLE
Add --wait-for-nodes flag

### DIFF
--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -106,6 +106,9 @@ parameters:
   - name: --vnet-name
     type: string
     short-summary: Name of the Virtual Network to create
+  - name: --wait-for-nodes
+    type: bool
+    short-summary: Wait for workload nodes to be ready
   - name: --windows -w
     type: bool
     short-summary: Enable options for Windows

--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -44,7 +44,7 @@ def load_arguments(self, _):
         ctx.argument('tags',
                      options_list=['--tags', '-t'],
                      help="Tags applied to the AKS management cluster and resource group if created in Azure")
-        ctx.argument('wait for nodes', options_list=['--wait-for-nodes', '-wn'], help="Wait for nodes to be ready")
+        ctx.argument('wait_for_nodes', options_list=['--wait-for-nodes', '-wn'], help="Wait for nodes to be ready")
 
     with self.argument_context('capi install') as ctx:
         ctx.argument('all_tools', options_list=['--all', '-a'], help="Install all tools")

--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -44,6 +44,7 @@ def load_arguments(self, _):
         ctx.argument('tags',
                      options_list=['--tags', '-t'],
                      help="Tags applied to the AKS management cluster and resource group if created in Azure")
+        ctx.argument('wait for nodes', options_list=['--wait-for-nodes', '-wn'], help="Wait for nodes to be ready")
 
     with self.argument_context('capi install') as ctx:
         ctx.argument('all_tools', options_list=['--all', '-a'], help="Install all tools")

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -625,8 +625,9 @@ clusterctl get kubeconfig {capi_name}
         kubectl_helpers.wait_for_nodes(workload_cfg)
 
     if wait_for_nodes:
+        total_machine_count = int(control_plane_machine_count) + int(node_machine_count)
         with Spinner(cmd, "Waiting for all workload cluster nodes to be ready", "✓ Workload cluster is ready"):
-            kubectl_helpers.wait_for_number_of_nodes(int(control_plane_machine_count) + int(node_machine_count), workload_cfg)
+            kubectl_helpers.wait_for_number_of_nodes(total_machine_count, workload_cfg)
 
     if pivot:
         pivot_cluster(cmd, workload_cfg)

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -455,6 +455,7 @@ def create_workload_cluster(  # pylint: disable=too-many-arguments,too-many-loca
         user_provided_template=None,
         bootstrap_commands=None,
         yes=False,
+        wait_for_nodes=False,
         tags=""):
 
     if location is None:
@@ -622,6 +623,10 @@ clusterctl get kubeconfig {capi_name}
     # Wait for all nodes to be ready before returning
     with Spinner(cmd, "Waiting for workload cluster nodes to be ready", "✓ Workload cluster is ready"):
         kubectl_helpers.wait_for_nodes(workload_cfg)
+
+    if wait_for_nodes:
+        with Spinner(cmd, "Waiting for all workload cluster nodes to be ready", "✓ Workload cluster is ready"):
+            kubectl_helpers.wait_for_number_of_nodes(int(control_plane_machine_count) + int(node_machine_count), workload_cfg)
 
     if pivot:
         pivot_cluster(cmd, workload_cfg)

--- a/src/capi/azext_capi/helpers/kubectl.py
+++ b/src/capi/azext_capi/helpers/kubectl.py
@@ -175,6 +175,7 @@ def wait_for_nodes(kubeconfig):
     error_msg = "Not all cluster nodes are Ready after 5 minutes."
     wait_for_resource_ready(find_nodes, error_msg, kubeconfig)
 
+
 def wait_for_number_of_nodes(number_of_nodes, kubeconfig=None,):
     """
     Waits for nodes of specified cluster to get be ready before proceeding.

--- a/src/capi/azext_capi/helpers/kubectl.py
+++ b/src/capi/azext_capi/helpers/kubectl.py
@@ -11,6 +11,7 @@ import subprocess
 import os
 import time
 import re
+import json
 
 from azure.cli.core.azclierror import UnclassifiedUserFault
 from azure.cli.core.azclierror import ResourceNotFoundError
@@ -173,6 +174,34 @@ def wait_for_nodes(kubeconfig):
     """
     error_msg = "Not all cluster nodes are Ready after 5 minutes."
     wait_for_resource_ready(find_nodes, error_msg, kubeconfig)
+
+def wait_for_number_of_nodes(number_of_nodes, kubeconfig=None,):
+    """
+    Waits for nodes of specified cluster to get be ready before proceeding.
+    Timeout: 5 minutes
+    """
+    error_msg = "Not all cluster nodes are Ready after 10 minutes."
+    command = ["kubectl", "get", "nodes", "-o", "json"]
+    command += add_kubeconfig_to_command(kubeconfig)
+    timeout = 60 * 10
+    start = time.time()
+    while time.time() < start + timeout:
+        try:
+            kubectl_output = run_shell_command(command)
+            json_output = json.loads(kubectl_output)
+            ready_nodes = 0
+            for item in json_output["items"]:
+                for condition in item["status"]["conditions"]:
+                    if condition["type"] == "Ready" and condition["status"] == "True":
+                        ready_nodes += 1
+            if ready_nodes < number_of_nodes:
+                time.sleep(5)
+                continue
+            return
+        except subprocess.CalledProcessError as err:
+            logger.info(err)
+            time.sleep(5)
+    raise ResourceNotFoundError(error_msg)
 
 
 def wait_for_resource_ready(find_resources, error_msg, kubeconfig=None,):

--- a/src/capi/azext_capi/helpers/kubectl.py
+++ b/src/capi/azext_capi/helpers/kubectl.py
@@ -176,7 +176,7 @@ def wait_for_nodes(kubeconfig):
     wait_for_resource_ready(find_nodes, error_msg, kubeconfig)
 
 
-def wait_for_number_of_nodes(number_of_nodes, kubeconfig=None,):
+def wait_for_number_of_nodes(number_of_nodes, kubeconfig=None):
     """
     Waits for nodes of specified cluster to get be ready before proceeding.
     Timeout: 5 minutes


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**
This PR adds an option flag `--wait-for-nodes` to `az capi create` which adds an extra step to wait for all the workload nodes to be created before exiting. The command currently returns as soon as the control plane is available, and ignores if errors happen to any workload nodes. Fixes #158 

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
