### PR TITLE
Fix resource group check

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -160,9 +160,7 @@ def create_aks_management_cluster(cmd, cluster_name, resource_group_name=None, l
         msg = f"Please provide a location for {resource_group_name} resource group"
         location = get_user_prompt_or_default(msg, default_location, skip_prompt=yes)
     # Don't recreate the resource group if it already exists: this overwrites existing tags.
-    try:
-        check_resource_group(cmd, resource_group_name, cluster_name, location)
-    except (CloudError, ResourceNotFoundException):
+    if not check_resource_group(cmd, resource_group_name, cluster_name, location):
         if not create_resource_group(cmd, resource_group_name, location, yes, tags):
             return False
     command = ["az", "aks", "create", "-g", resource_group_name, "--name", cluster_name, "--generate-ssh-keys",
@@ -429,7 +427,8 @@ def check_resource_group(cmd, resource_group_name, default_resource_group_name, 
             msg = "--location is required to create the resource group {}."
             raise RequiredArgumentMissingError(msg.format(resource_group_name)) from err
         logger.warning("Could not find an Azure resource group, CAPZ will create one for you")
-    return resource_group_name
+        return False
+    return True
 
 
 # pylint: disable=inconsistent-return-statements
@@ -500,7 +499,7 @@ def create_workload_cluster(  # pylint: disable=too-many-arguments,too-many-loca
         bootstrap_cmds["pre"] += kubeadm_file_commands["pre"]
         bootstrap_cmds["post"] += kubeadm_file_commands["post"]
 
-    resource_group_name = check_resource_group(cmd, resource_group_name, capi_name, location)
+    check_resource_group(cmd, resource_group_name, capi_name, location)
 
     msg = f'Create the Kubernetes cluster "{capi_name}" in the Azure resource group "{resource_group_name}"?'
     if not yes and not prompt_y_n(msg, default="n"):

--- a/src/capi/azext_capi/tests/latest/test_capi_scenario.py
+++ b/src/capi/azext_capi/tests/latest/test_capi_scenario.py
@@ -27,7 +27,10 @@ class CapiScenarioTest(ScenarioTest):
         with patch('azext_capi._client_factory.cf_resource_groups') as cf_resource_groups:
             cf_resource_groups.return_value = mock_client
             with self.assertRaises(RequiredArgumentMissingError):
+                location = os.environ.pop('AZURE_LOCATION', None)
                 self.cmd('capi create')
+                if location:
+                    os.environ['AZURE_LOCATION'] = location
         # Test that --name is the only required arg if it already exists
         with patch('azext_capi._client_factory.cf_resource_groups') as cf_resource_groups:
             # If we got to user confirmation (NoTTYException), RG validation succeeded
@@ -44,7 +47,10 @@ class CapiScenarioTest(ScenarioTest):
         with patch('azext_capi._client_factory.cf_resource_groups') as cf_resource_groups:
             cf_resource_groups.return_value = mock_client
             with self.assertRaises(RequiredArgumentMissingError):
+                location = os.environ.pop('AZURE_LOCATION', None)
                 self.cmd('capi create -n myClusterName -g myCluster')
+                if location:
+                    os.environ['AZURE_LOCATION'] = location
         # New RG, no --location, AZURE_LOCATION set
         with patch.dict('os.environ', {"AZURE_LOCATION": "westus3"}):
             with patch('azext_capi.custom.check_resource_group') as mock_check_rg:


### PR DESCRIPTION
The `check_resource_group` function was being called from AKS mgmt cluster creation, but that invocation apparently expected it to raise exceptions that it does not. I refactored it to return a boolean, which seems to fix `az aks create -y` in my testing. I also fixed some related unit tests to work regardless of `AZURE_LOCATION` being set.

**Description**

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
