### PR TITLE
Simplify waiting for nodes

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -620,14 +620,11 @@ clusterctl get kubeconfig {capi_name}
         apply_kubernetes_manifest(cmd, kubeproxy_manifest_file, workload_cfg, spinner_enter_message,
                                   spinner_exit_message, error_message)
 
-    # Wait for all nodes to be ready before returning
-    with Spinner(cmd, "Waiting for workload cluster nodes to be ready", "✓ Workload cluster is ready"):
-        kubectl_helpers.wait_for_nodes(workload_cfg)
-
-    if wait_for_nodes:
-        total_machine_count = int(control_plane_machine_count) + int(node_machine_count)
-        with Spinner(cmd, "Waiting for all workload cluster nodes to be ready", "✓ Workload cluster is ready"):
-            kubectl_helpers.wait_for_number_of_nodes(total_machine_count, workload_cfg)
+    # Wait for a node (or all nodes) to be ready before returning
+    node_count = 1 if not wait_for_nodes else int(control_plane_machine_count) + int(node_machine_count)
+    plural = "s" if node_count > 1 else ""
+    with Spinner(cmd, f"Waiting for {node_count} node{plural} to be ready", "✓ Workload cluster is ready"):
+        kubectl_helpers.wait_for_number_of_nodes(node_count, workload_cfg)
 
     if pivot:
         pivot_cluster(cmd, workload_cfg)

--- a/src/capi/azext_capi/helpers/kubectl.py
+++ b/src/capi/azext_capi/helpers/kubectl.py
@@ -167,15 +167,6 @@ def find_nodes(kubeconfig):
     return find_kubectl_resource_names("nodes", error_msg, kubeconfig)
 
 
-def wait_for_nodes(kubeconfig):
-    """
-    Waits for nodes of specified cluster to get be ready before proceeding.
-    Timeout: 5 minutes
-    """
-    error_msg = "Not all cluster nodes are Ready after 5 minutes."
-    wait_for_resource_ready(find_nodes, error_msg, kubeconfig)
-
-
 def wait_for_number_of_nodes(number_of_nodes, kubeconfig=None):
     """
     Waits for nodes of specified cluster to get be ready before proceeding.


### PR DESCRIPTION
**Description**

`az capi create` had two separate phases of "Waiting for nodes". This collapses them into one and removes some unused code.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
