### PR TITLE
Increase wait_for_number_of_nodes timeout to 15 minutes

### DIFF
--- a/src/capi/azext_capi/helpers/kubectl.py
+++ b/src/capi/azext_capi/helpers/kubectl.py
@@ -170,12 +170,12 @@ def find_nodes(kubeconfig):
 def wait_for_number_of_nodes(number_of_nodes, kubeconfig=None):
     """
     Waits for nodes of specified cluster to get be ready before proceeding.
-    Timeout: 5 minutes
+    Timeout: 15 minutes
     """
     error_msg = "Not all cluster nodes are Ready after 10 minutes."
     command = ["kubectl", "get", "nodes", "-o", "json"]
     command += add_kubeconfig_to_command(kubeconfig)
-    timeout = 60 * 10
+    timeout = 60 * 15
     start = time.time()
     while time.time() < start + timeout:
         try:


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**
We noticed that for windows clusters, it takes a longer time for nodes to come up as ready. We are increasing the timeout to 15 minutes because of this issue.

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->
Increase wait_for_number_of_nodes timeout to 15 minutes
---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
