### PR TITLE
Fix tab completion for --name

### DIFF
--- a/src/capi/azext_capi/_completers.py
+++ b/src/capi/azext_capi/_completers.py
@@ -32,7 +32,7 @@ def get_kubernetes_version_completion_list(cmd, prefix, namespace, **kwargs):  #
 def get_workflow_clusters_completion_list(cmd, prefix, namespace, **kwargs):  # pylint: disable=unused-argument
     from .custom import list_workload_clusters
 
-    clusters = list_workload_clusters(None)
+    clusters = list_workload_clusters(cmd)
     return [i['metadata']['name'] for i in clusters.get('items', [])]
 
 


### PR DESCRIPTION
**Description**

Tab completion for the `--name|-n` parameter broke silently because `cmd` was `None`.

The completer's code path from `get_workflow_clusters_completion_list` ends up calling the `tab_separated_output` function which references `cmd.cli_ctx`. This presumably raised an error which was swallowed by the CLI framework. Passing the `cmd` through  works.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
