### PR TITLE
Make --wait-for-nodes a user-supplied integer

### DIFF
--- a/src/capi/HISTORY.rst
+++ b/src/capi/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 
 * Default `az capi create --kubernetes-version` to v1.25.3
 * Install Calico CNI with official Helm chart
+* Add "--wait-for-nodes" argument to "az capi create"
 
 0.0.6
 ++++++

--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -107,8 +107,8 @@ parameters:
     type: string
     short-summary: Name of the Virtual Network to create
   - name: --wait-for-nodes
-    type: bool
-    short-summary: Wait for workload nodes to be ready
+    type: integer
+    short-summary: Wait for N nodes to be ready
   - name: --windows -w
     type: bool
     short-summary: Enable options for Windows

--- a/src/capi/azext_capi/_params.py
+++ b/src/capi/azext_capi/_params.py
@@ -41,10 +41,9 @@ def load_arguments(self, _):
         ctx.argument('management_cluster_resource_group_name',
                      options_list=['--management-cluster-resource-group-name', '-mg'],
                      help="Resource group name of management cluster")
-        ctx.argument('tags',
-                     options_list=['--tags', '-t'],
+        ctx.argument('tags', options_list=['--tags', '-t'],
                      help="Tags applied to the AKS management cluster and resource group if created in Azure")
-        ctx.argument('wait_for_nodes', options_list=['--wait-for-nodes', '-wn'], help="Wait for nodes to be ready")
+        ctx.argument('wait_for_nodes', options_list=['--wait-for-nodes', '-wn'], help="Wait for N nodes to be ready")
 
     with self.argument_context('capi install') as ctx:
         ctx.argument('all_tools', options_list=['--all', '-a'], help="Install all tools")

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -460,11 +460,13 @@ def create_workload_cluster(  # pylint: disable=too-many-arguments,too-many-loca
         user_provided_template=None,
         bootstrap_commands=None,
         yes=False,
-        wait_for_nodes=False,
+        wait_for_nodes=1,
         tags=""):
 
     if location is None:
         location = os.environ.get("AZURE_LOCATION", None)
+
+    wait_for_nodes = int(wait_for_nodes)
 
     if not capi_name:
         from .helpers.names import generate_cluster_name
@@ -596,10 +598,10 @@ clusterctl get kubeconfig {capi_name}
     install_cni(cmd, capi_name, workload_cfg, windows, args)
 
     # Wait for a node (or all nodes) to be ready before returning
-    node_count = 1 if not wait_for_nodes else int(control_plane_machine_count) + int(node_machine_count)
-    plural = "s" if node_count > 1 else ""
-    with Spinner(cmd, f"Waiting for {node_count} node{plural} to be ready", "✓ Workload cluster is ready"):
-        kubectl_helpers.wait_for_number_of_nodes(node_count, workload_cfg)
+    if wait_for_nodes > 0:
+        plural = "s" if wait_for_nodes > 1 else ""
+        with Spinner(cmd, f"Waiting for {wait_for_nodes} node{plural} to be ready", "✓ Workload cluster is ready"):
+            kubectl_helpers.wait_for_number_of_nodes(wait_for_nodes, workload_cfg)
 
     if pivot:
         pivot_cluster(cmd, workload_cfg)


### PR DESCRIPTION
**Description**

Changes the `--wait-for-nodes` argument to `az capi create` from a boolean to an integer defaulting to 1, and removes the default control_plane_node_count + workload_node_count calculation.

This puts more burden on the user to be explicit about their cluster size and shape, but we think in many cases the default logic described above would fail, so it needs to be customizable. Redefining the existing argument a bit avoids adding yet another one.

**History Notes**

```
az capi create: make --wait-for-nodes a user-supplied integer
```

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
