### PR TITLE
Improve kind install helper

### DIFF
--- a/src/capi/azext_capi/helpers/binary.py
+++ b/src/capi/azext_capi/helpers/binary.py
@@ -152,13 +152,16 @@ def install_helm(_cmd, client_version="v3.10.2", install_location=None, source_u
         os.remove(tarball)
 
 
-def install_kind(_cmd, client_version="v0.10.0", install_location=None, source_url=None):
+def install_kind(_cmd, client_version="v0.17.0", install_location=None, source_url=None):
     """
     Install kind, a container-based Kubernetes environment for development and testing.
     """
 
+    system = platform.system()
+    platform_os = system.lower()
+    arch = get_arch()
     if not source_url:
-        source_url = "https://kind.sigs.k8s.io/dl/{}/kind-{}-{}"
+        source_url = f"https://kind.sigs.k8s.io/dl/{client_version}/kind-{platform_os}-{arch}"
 
     # ensure installation directory exists
     if install_location is not None:
@@ -171,19 +174,7 @@ def install_kind(_cmd, client_version="v0.10.0", install_location=None, source_u
     if not os.path.exists(install_dir):
         os.makedirs(install_dir)
 
-    file_url = ""
-    system = platform.system()
-    arch = get_arch()
-    if system == "Windows":
-        file_url = source_url.format(client_version, "windows", arch)
-    elif system == "Linux":
-        file_url = source_url.format(client_version, "linux", arch)
-    elif system == "Darwin":
-        file_url = source_url.format(client_version, "darwin", arch)
-    else:
-        raise InvalidArgumentValueError(f'System "{system}" is not supported by kind.')
-
-    return download_binary(install_location, install_dir, file_url, system, cli)
+    return download_binary(install_location, install_dir, source_url, system, cli)
 
 
 def install_kubectl(cmd, client_version="latest", install_location=None, source_url=None):


### PR DESCRIPTION
**Description**

The `install_kind` function defaulted to an old version and wasn't taking into account the platform architecture. This fetches the latest official release for the correct architecture.

I would default to "latest" instead of hard-coding a version, but that gets us a prerelease version:

```shell
% ./env/bin/kind version                                    
kind v0.18.0-alpha+7d26b50a129faf go1.19.3 darwin/arm64
```

I think it's safer to pin to a known-working version and update periodically than to use alpha builds of `kind`.

I've tested this locally.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
