### PR TITLE
Update GitHub actions and python versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.163.1/containers/python-3/.devcontainer/base.Dockerfile
 
-# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
+# [Choice] Python version: 3, 3.11, 3.10, 3.9, 3.8, 3.7
 ARG VARIANT="3"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,8 @@
 		"dockerfile": "Dockerfile",
 		"context": "..",
 		"args": {
-			// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
-			"VARIANT": "3.6",
+			// Update 'VARIANT' to pick a Python version: 3, 3.7, 3.8, 3.9, 3.10, 3.11
+			"VARIANT": "3.10",
 			// Options
 			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.6
 
@@ -57,7 +57,7 @@ jobs:
         az extension list
         az capi -h
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: dist
         path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   schedule:
-    - cron: '45 0 * * *' # Every day at 00:45 UTC 
+    - cron: '45 0 * * *' # Every day at 00:45 UTC
   workflow_dispatch:
 
 env:
@@ -20,7 +20,7 @@ jobs:
 
     - uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |
@@ -30,7 +30,7 @@ jobs:
         python -m pip install -U pip
         python -m pip install -r requirements.txt
         azdev setup --repo . --ext capi
-    
+
     - name: Build extension
       run: |
         source env/bin/activate

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ extension to your Azure CLI to harness the power and flexibility of
 
 ## Developer Setup
 
-Developing this Azure CLI extension requires a virtual environment with Python 3.6 or later,
+Developing this Azure CLI extension requires a virtual environment with Python 3.7 or later,
 several required libraries, and the `azdev` tool.
 
 You can jump into development right now on the web or on your workstation with
@@ -41,7 +41,7 @@ running. After a few minutes, the virtual environment will be configured and rea
 
 ### Local Environment
 
-Create a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for Python 3.6 or
+Create a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for Python 3.7 or
 later, activate it, install required libraries, and tell the `azdev` tool about our
 "capi" extension:
 

--- a/src/capi/setup.py
+++ b/src/capi/setup.py
@@ -27,10 +27,11 @@ CLASSIFIERS = [
     'Intended Audience :: System Administrators',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'License :: OSI Approved :: MIT License',
 ]
 


### PR DESCRIPTION
**Description**

CI recently began failing because Python 3.6 is no longer supported. This updates the GH actions we use and bumps the python version support to 3.7 - 3.11.

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
