### PR TITLE
Hide clusterctl output unless --debug

### DIFF
--- a/src/capi/azext_capi/helpers/kubectl.py
+++ b/src/capi/azext_capi/helpers/kubectl.py
@@ -131,7 +131,7 @@ def get_kubeconfig(capi_name):
     """Writes kubeconfig of specified cluster"""
     cmd = ["clusterctl", "get", "kubeconfig", capi_name]
     try:
-        output = run_shell_command(cmd, combine_std=False)
+        output = run_shell_command(cmd)
     except subprocess.CalledProcessError as err:
         raise UnclassifiedUserFault("Couldn't get kubeconfig") from err
     filename = capi_name + ".kubeconfig"


### PR DESCRIPTION
**Description**

The polling for the workload cluster's kubeconfig was accidentally printing to stdout even without the `--debug` flag.

Fixes #142

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
