### PR TITLE
Apply Windows kube-proxy manifest

### DIFF
--- a/src/capi/HISTORY.rst
+++ b/src/capi/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.1.1
+++++++
+
+* Apply Windows kube-proxy manifest
+
 0.1.0
 ++++++
 

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -686,6 +686,8 @@ def install_cni_windows(cmd, args, workload_cfg, spinner_enter_message, spinner_
     kubeproxy_manifest_file = "kube-proxy-windows.yaml"
     manifest = render_custom_cluster_template(kubeproxy_manifest_url, kubeproxy_manifest_file, args)
     write_to_file(kubeproxy_manifest_file, manifest)
+    apply_kubernetes_manifest(cmd, kubeproxy_manifest_file, workload_cfg, spinner_enter_message,
+                              spinner_exit_message, error_message)
 
 
 def pivot_cluster(cmd, target_cluster_kubeconfig):

--- a/src/capi/setup.py
+++ b/src/capi/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 
 # Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
**Description**

The Windows kube-proxy manifest was being prepared but not applied.

**History Notes**

Fix: apply Windows kube-proxy manifest

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
