### PR TITLE
Remove Felix override workaround

### DIFF
--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -658,15 +658,6 @@ def install_cni(cmd, cluster_name, workload_cfg, windows, args):
     error_message = "Couldn't install CNI after waiting 5 minutes."
     install_helm_chart(cmd, helminfo, workload_cfg, spinner_enter_message, spinner_exit_message, error_message)
 
-    # Apply felix-override manifest.
-    spinner_enter_message = "Applying felix-override manifest"
-    spinner_exit_message = "✓ Applied felix-override manifest"
-    error_message = "Couldn't apply felix-override manifest after waiting 5 minutes."
-    felix_manifest = "https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/" + \
-        "main/templates/addons/calico/felix-override.yaml"
-    apply_kubernetes_manifest(cmd, felix_manifest, workload_cfg, spinner_enter_message,
-                              spinner_exit_message, error_message)
-
     if windows:
         install_cni_windows(cmd, args, workload_cfg, spinner_enter_message, spinner_exit_message, error_message)
 


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**

Reported by @huntergregory

> It seems az capi create is currently failing with the [newest capi extension version](https://github.com/Azure/azure-capi-cli-extension/releases). It seems this commit removed a file resulting in a 404 error.
[Remove Calico felix override workaround · kubernetes-sigs/cluster-api-provider-azure@34c05f8 (](https://github.com/kubernetes-sigs/cluster-api-provider-azure/commit/34c05f84d17b65ab357cd2ef074c9ddae2d20eb8)[github.com](http://github.com/)[)](https://github.com/kubernetes-sigs/cluster-api-provider-azure/commit/34c05f84d17b65ab357cd2ef074c9ddae2d20eb8)
cli: ✓ Deployed CNI to workload cluster
 cli: Applying felix-override manifest.
 error: unable to read URL "https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico/felix-override.yaml["](https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico/felix-override.yaml%22), server reported 404 Not Found, status code=404
 cli: Command '['kubectl', 'apply', '-f', 'https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico/felix-override.yaml['](https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico/felix-override.yaml%27), '--kubeconfig', 'hgregory-capz-conf-fwdcs7.kubeconfig']' returned non-zero exit status 1.

This PR removes the felix override workaround as it is no longer needed.

**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
