### PR TITLE
Updating az capi to be able to deploy KPNG on windows instead of in-tree kube-proxy

### DIFF
--- a/src/capi/HISTORY.rst
+++ b/src/capi/HISTORY.rst
@@ -7,6 +7,7 @@ Release History
 +++++
 
 * Update docker-in-docker script for CodeSpaces
+* Update to install KPNG instead of in-tree kube-proxy for Windows nodes
 
 0.1.2
 +++++

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -659,10 +659,17 @@ def install_cni(cmd, cluster_name, workload_cfg, windows, args):
     install_helm_chart(cmd, helminfo, workload_cfg, spinner_enter_message, spinner_exit_message, error_message)
 
     if windows:
-        install_cni_windows(cmd, args, workload_cfg, spinner_enter_message, spinner_exit_message, error_message)
+        install_cni_windows(cmd, workload_cfg, spinner_enter_message, spinner_exit_message, error_message)
+        windows_kpng = os.environ.get('WINDOWS_KPNG')
+        if not windows_kpng:
+            install_windows_kubeproxy(cmd, args, workload_cfg, spinner_enter_message,
+                                      spinner_exit_message, error_message)
+        else:
+            install_windows_kpng(cmd, args, workload_cfg, spinner_enter_message,
+                                 spinner_exit_message, error_message)
 
 
-def install_cni_windows(cmd, args, workload_cfg, spinner_enter_message, spinner_exit_message, error_message):
+def install_cni_windows(cmd, workload_cfg, spinner_enter_message, spinner_exit_message, error_message):
     """Copy a configmap and install Windows CNI via manifest: workarounds until the Helm chart supports Windows."""
     configmap = get_configmap(workload_cfg, "kubeadm-config", "kube-system")
     configmap = configmap.replace("namespace: kube-system", "namespace: calico-system")
@@ -673,11 +680,38 @@ def install_cni_windows(cmd, args, workload_cfg, spinner_enter_message, spinner_
     error_message = "Couldn't install Windows Calico support after waiting 5 minutes."
     apply_kubernetes_manifest(cmd, calico_manifest, workload_cfg, spinner_enter_message,
                               spinner_exit_message, error_message)
+
+
+def install_windows_kubeproxy(cmd, args, workload_cfg, spinner_enter_message, spinner_exit_message, error_message):
     kubeproxy_manifest_url = "https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/windows/calico/kube-proxy-windows.yaml"  # pylint: disable=line-too-long
     kubeproxy_manifest_file = "kube-proxy-windows.yaml"
     manifest = render_custom_cluster_template(kubeproxy_manifest_url, kubeproxy_manifest_file, args)
     write_to_file(kubeproxy_manifest_file, manifest)
+    spinner_enter_message = "Deploying Windows kube-proxy"
+    spinner_exit_message = "✓ Deployed Windows kube-proxy to workload cluster"
+    error_message = "Couldn't install Windows kube-proxy after waiting 5 minutes."
     apply_kubernetes_manifest(cmd, kubeproxy_manifest_file, workload_cfg, spinner_enter_message,
+                              spinner_exit_message, error_message)
+
+
+def install_windows_kpng(cmd, args, workload_cfg, spinner_enter_message, spinner_exit_message, error_message):
+    kpng_rbac_manifest_url = "https://raw.githubusercontent.com/kubernetes-sigs/windows-service-proxy/main/deploy/kpng-rbac.yaml"  # pylint: disable=line-too-long
+    kpng_rbac_manifest_file = "kpng-rback.yaml"
+    kpng_rbac_manifest = render_custom_cluster_template(kpng_rbac_manifest_url, kpng_rbac_manifest_file, args)
+    write_to_file(kpng_rbac_manifest_file, kpng_rbac_manifest)
+    spinner_enter_message = "Deploying Windows kpng-rbac rules"
+    spinner_exit_message = "✓ Deployed Windows kpng-rbac rules workload cluster"
+    error_message = "Couldn't install Windows kpng-rbac after waiting 5 minutes."
+    apply_kubernetes_manifest(cmd, kpng_rbac_manifest_file, workload_cfg, spinner_enter_message,
+                              spinner_exit_message, error_message)
+    kpng_manifest_url = "https://raw.githubusercontent.com/kubernetes-sigs/windows-service-proxy/main/deploy/kpng-windows-capz-calico.yaml"  # pylint: disable=line-too-long
+    kpng_manifest_file = "kpng.yaml"
+    kpng_manifest = render_custom_cluster_template(kpng_manifest_url, kpng_manifest_file, args)
+    write_to_file(kpng_manifest_file, kpng_manifest)
+    spinner_enter_message = "Deploying Windows kpng"
+    spinner_exit_message = "✓ Deployed Windows kpng to workload cluster"
+    error_message = "Couldn't install Windows kpng after waiting 5 minutes."
+    apply_kubernetes_manifest(cmd, kpng_manifest_file, workload_cfg, spinner_enter_message,
                               spinner_exit_message, error_message)
 
 


### PR DESCRIPTION

Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**
Updating az capi to be able to deploy KPNG on windows instead of in-tree kube-proxy

**History Notes**
Updating az capi to be able to deploy KPNG on windows instead of in-tree kube-proxy

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
