### PR TITLE
Update google storage URL to dl.k8s.io

### DIFF
--- a/src/capi/azext_capi/helpers/binary.py
+++ b/src/capi/azext_capi/helpers/binary.py
@@ -183,7 +183,7 @@ def install_kubectl(cmd, client_version="latest", install_location=None, source_
     """
 
     if not source_url:
-        source_url = "https://storage.googleapis.com/kubernetes-release/release"
+        source_url = "https://dl.k8s.io/release"
         cloud_name = cmd.cli_ctx.cloud.name
         if cloud_name.lower() == "azurechinacloud":
             source_url = "https://mirror.azure.cn/kubernetes/kubectl"


### PR DESCRIPTION
**Description**

Updates a Google storage URL to the preferred dl.k8s.io. See kubernetes/k8s.io#2396 and kubernetes-sigs/cluster-api#4958 for more details.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
