### PR TITLE
Pin to working version of azdev

### DIFF
--- a/create-dev-env.sh
+++ b/create-dev-env.sh
@@ -22,5 +22,5 @@ fi
 source ./env/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
-pip install azdev
+pip install azdev==0.1.48
 azdev setup --repo . --ext capi --verbose

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-azdev
+azdev==0.1.48
 black
 coverage
 Jinja2


### PR DESCRIPTION
**Description**

Changes to the `azdev` CLI developer tool in v0.1.49 broke our CI and local development workflow:

```shell
% azdev                     
[Errno 2] No such file or directory: '_NONE_/scripts/ci/cmdcov.yml'
```

This pins `azdev` to known-working version v0.1.48.

See Azure/azure-cli-dev-tools#407

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
