### PR TITLE
Default to external cloud provider

### DIFF
--- a/src/capi/HISTORY.rst
+++ b/src/capi/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 0.1.6
 +++++
+* `--external-cloud-provider=true` is now the default for `az capi create`
 
 0.1.5
 +++++

--- a/src/capi/azext_capi/templates/KubeadmConfig.yaml
+++ b/src/capi/azext_capi/templates/KubeadmConfig.yaml
@@ -9,7 +9,7 @@ spec:
       name: {% raw %}'{{ ds.meta_data["local_hostname"] }}'{% endraw %}
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
+        cloud-provider: {% if EXTERNAL_CLOUD_PROVIDER %}external{% else %}azure{% endif %}
         cloud-config: /etc/kubernetes/azure.json
   files:
   - contentFrom:

--- a/src/capi/azext_capi/templates/KubeadmControlPlane.yaml
+++ b/src/capi/azext_capi/templates/KubeadmControlPlane.yaml
@@ -29,7 +29,7 @@ spec:
       apiServer:
         timeoutForControlPlane: 20m
         extraArgs:
-          cloud-provider: azure
+          cloud-provider: {% if EXTERNAL_CLOUD_PROVIDER %}external{% else %}azure{% endif %}
           cloud-config: /etc/kubernetes/azure.json
           {%- if WINDOWS %}
           feature-gates: WindowsHostProcessContainers=true
@@ -54,7 +54,7 @@ spec:
         local:
           dataDir: /var/lib/etcddisk/etcd
           extraArgs:
-            quota-backend-bytes: "8589934592"  
+            quota-backend-bytes: "8589934592"
     files:
     - contentFrom:
         secret:


### PR DESCRIPTION
**Description**

Sets `--external-cloud-provider=true` as the default to `az capi create`. It's time; without this, Kubernetes v1.29.x clusters won't work.

Fixes #188

**History Notes**

`--external-cloud-provider=true` is now the default for `az capi create`

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
