### PR TITLE
Mask specified log output

### DIFF
--- a/src/capi/HISTORY.rst
+++ b/src/capi/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.7
++++++
+* Mask sensitive data values in --verbose or --debug log output
+
 0.1.6
 +++++
 * `--external-cloud-provider=true` is now the default for `az capi create`

--- a/src/capi/azext_capi/helpers/kubectl.py
+++ b/src/capi/azext_capi/helpers/kubectl.py
@@ -131,7 +131,8 @@ def get_kubeconfig(capi_name):
     """Writes kubeconfig of specified cluster"""
     cmd = ["clusterctl", "get", "kubeconfig", capi_name]
     try:
-        output = run_shell_command(cmd)
+        mask_fields = ["certificate-authority-data", "client-certificate-data", "client-key-data"]
+        output = run_shell_command(cmd, mask_fields=mask_fields)
     except subprocess.CalledProcessError as err:
         raise UnclassifiedUserFault("Couldn't get kubeconfig") from err
     filename = capi_name + ".kubeconfig"

--- a/src/capi/setup.py
+++ b/src/capi/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 
 # Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.1.6'
+VERSION = '0.1.7'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
**Description**

Allows commands to specify certain output fields to be masked, so their values will appear in log output as `"****"`. This mechanism works for the `--verbose` and `--debug` flags for commands, assuming JSON or YAML-type output.

Fixes #248 

**History Notes**

az capi: Mask sensitive data values in --verbose or --debug log output

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
