### PR TITLE
Fix mask implementation to change only log

### DIFF
--- a/src/capi/azext_capi/helpers/run_command.py
+++ b/src/capi/azext_capi/helpers/run_command.py
@@ -20,11 +20,8 @@ def run_shell_command(command, combine_std=True, mask_fields=None):
     if combine_std:
         stderr = None if is_verbose() else subprocess.STDOUT
     output = subprocess.check_output(command, universal_newlines=True, stderr=stderr)
-    output = mask(output, mask_fields)
-    if mask_fields and output:
-        for field in mask_fields:
-            output = mask(output, field)
-    logger.info("%s returned:\n%s", " ".join(command), output)
+    log_output = mask(output, mask_fields)
+    logger.info("%s returned:\n%s", " ".join(command), log_output)
     return output
 
 


### PR DESCRIPTION
**Description**

Fixes a big bug in the implementation of `mask()` that could munge the actual data, when the intention was only to mask logged output.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
