### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ![Python](https://img.shields.io/pypi/pyversions/azure-cli.svg?maxAge=2592000)
 ![.github/workflows/build.yml](https://github.com/Azure/azure-capi-cli-extension/workflows/.github/workflows/build.yml/badge.svg)
 
+## ⚠ This project is deprecated ⚠
+
+azure-capi-cli-extension is no longer maintained.
+
 The **Kubernetes Cluster API extension for Azure CLI** helps you create, evolve, and maintain
 [Kubernetes](https://kubernetes.io/) clusters on Azure in a familiar, declarative way. Add this
 extension to your Azure CLI to harness the power and flexibility of


### PR DESCRIPTION
**Description**

Adds a short blurb at the top of the README clarifying that `az capi` is no longer maintained.

See #263.

**History Notes**

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
